### PR TITLE
Add support for subcontexts

### DIFF
--- a/distarray/odin.py
+++ b/distarray/odin.py
@@ -36,7 +36,7 @@ def all_equal(lst):
     if len(lst) == 0 or len(lst) == 1:
         return True  # vacuously True
     else:
-        return all([element == lst[0] for element in lst[1:]])
+        return all(element == lst[0] for element in lst[1:])
 
 
 def key_and_push_args(subcontext, arglist):
@@ -69,11 +69,14 @@ def key_and_push_args(subcontext, arglist):
     return arg_keys
 
 
-def determine_context(args):
+def determine_context(definition_context, args):
     """Determine the DistArrayContext for a function.
 
     Parameters
     ----------
+    definition_context: DistArrayContext object
+        The Context in which the function was defined.
+
     args : iterable
         List of objects to inspect for context.  Objects that aren't of
         type DistArrayProxy are skipped.
@@ -88,15 +91,12 @@ def determine_context(args):
     ValueError
         Raised if all DistArrayProxy objects don't have the same context.
     """
-    contexts = [arg.context for arg in args if isinstance(arg, DistArrayProxy)]
-    if len(contexts) == 0:
-        return context  # use the module-provided context
-    elif not all_equal(contexts):
-        errmsg = "All DistArrayProxy objects must be defined in the same context: {}"
+    contexts = [definition_context] + [arg.context for arg in args if isinstance(arg, DistArrayProxy)]
+    if not all_equal(contexts):
+        errmsg = "All DistArrayProxy objects must be defined with the same context used for the function: {}"
         raise ValueError(errmsg.format(contexts))
     else:
         return contexts[0]
-
 
 def local(fn):
     """ Decorator indicating a function is run locally on engines.
@@ -117,7 +117,7 @@ def local(fn):
 
     def inner(*args, **kwargs):
 
-        subcontext = determine_context(flatten((args, kwargs.values())))
+        subcontext = determine_context(_global_context, flatten((args, kwargs.values())))
 
         # generate keys for each parameter
         # push to engines if not a DistArrayProxy

--- a/distarray/tests/test_odin.py
+++ b/distarray/tests/test_odin.py
@@ -168,8 +168,8 @@ class TestLocal(unittest.TestCase):
         subcontext = DistArrayContext(odin._global_view, targets=targets)
         da = subcontext.empty((1024, 1024))
         da.fill(11)
-        de = local_add_num(da, 10)
-        assert_allclose(de, 11 + 10)
+        with self.assertRaises(ValueError):
+            local_add_num(da, 10)
 
     def test_barrier(self):
         call_barrier(self.da)
@@ -178,8 +178,8 @@ class TestLocal(unittest.TestCase):
         targets = [0, 2]
         subcontext = DistArrayContext(odin._global_view, targets=targets)
         da = subcontext.empty((1024, 1024))
-        da.fill(11)
-        call_barrier(da)
+        with self.assertRaises(ValueError):
+            call_barrier(da)
 
 class TestUtils(unittest.TestCase):
 
@@ -206,27 +206,27 @@ class TestDetermineContext(unittest.TestCase):
     def test_global_context(self):
         da = odin.context.empty((100,))
         db = odin.context.empty((100,))
-        self.assertEqual(odin.determine_context((da, db)), odin.context)
+        self.assertEqual(odin.determine_context(odin.context, (da, db)), odin.context)
 
     def test_subcontext(self):
         subcontext = DistArrayContext(odin._global_view, targets=[0, 3])
         da = subcontext.empty((100,))
         db = subcontext.empty((100,))
-        self.assertEqual(odin.determine_context((da, db)), subcontext)
+        self.assertEqual(odin.determine_context(subcontext, (da, db)), subcontext)
 
     def test_no_proxies(self):
-        self.assertEqual(odin.determine_context((11, 12, 'abc')), odin.context)
+        self.assertEqual(odin.determine_context(odin.context, (11, 12, 'abc')), odin.context)
 
     def test_mixed_types(self):
         subcontext = DistArrayContext(odin._global_view, targets=[0, 3])
         da = subcontext.empty((100,))
-        self.assertEqual(odin.determine_context((da, 12, 'abc')), da.context)
+        self.assertEqual(odin.determine_context(subcontext, (da, 12, 'abc')), da.context)
 
     def test_mixed_contexts(self):
         subcontext = DistArrayContext(odin._global_view, targets=[0, 3])
         da = odin.context.empty((100,))
         db = subcontext.empty((100,))
-        self.assertRaises(ValueError, odin.determine_context, (da, db))
+        self.assertRaises(ValueError, odin.determine_context, odin.context, (da, db))
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Apply `@local`-wrapped functions in the context implied by their passed-in DistArrayProxies.  If no DistArrayProxies are passed in, use `odin.context`.

This PR also includes Min RK's fix.
