### PR TITLE
FIX: Fix for issue #12.

### DIFF
--- a/distarray/tests/test_client.py
+++ b/distarray/tests/test_client.py
@@ -27,7 +27,8 @@ class TestClient(unittest.TestCase):
             dac = DistArrayContext(subview)
 
     def testCreateDACwithTargetsRanks(self):
-        '''Is the ranks attribute of a Context object contiguous?'''
-        targets = [2,3]
+        '''Check that the target <=> rank mapping is consistent.'''
+        targets = [3,2]
         dac = DistArrayContext(self.dv, targets=targets)
-        self.assertEqual(set(dac.ranks), set(range(len(targets))))
+        self.assertEqual(set(dac.targets), set(dac.target_to_rank.keys()))
+        self.assertEqual(set(range(len(dac.targets))), set(dac.target_to_rank.values()))


### PR DESCRIPTION
It is necessary to get the ranks for the intracommunicator created by
the DistArayContext's **init**() since an intracomm's ranks may be in an
arbitrary order when compared to the ranks of the parent communicator.
The mapping between engine ID's and the intracomm's ranks is the correct
association to use.

This bugfix refactors the **init**() method into two private methods: `_make_intracomm()` which creates the intracommunicator for use by a `DistArrayContext` object, and `_set_engine_rank_mapping()` which sets the `ranks` attribute accordingly.
