### PR TITLE
Update IPython-Parallel usage

### DIFF
--- a/distarray/client.py
+++ b/distarray/client.py
@@ -78,7 +78,8 @@ class DistArrayContext(object):
                 assert target in all_targets, "engine with id %r not registered" % target
                 self.targets.append(target)
 
-        self.view.execute('import distarray', block=True)
+        with self.view.sync_imports():
+            import distarray
 
         self._make_intracomm()
         self._set_engine_rank_mapping()


### PR DESCRIPTION
Small pull request; there was going to be more changes in this one, mainly centered around replacing the usage of `execute` in the codebase.  Upon discussion with @kwmsmith, I think we've decided to refactor the `local` decorator first, and then factor out a lot of these `execute` statements with that.

If you can see other things which should go in this, please comment.

Addresses #21 
