### PR TITLE
Fix TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - pip install numpy
     - pip install pyzmq --install-option="--zmq=bundled"
     - pip install ipython
-    - pip install mpi4py
+    - pip install mpi4py --allow-all-external --allow-unverified mpi4py
     - pip install six
     - pip freeze
 install:


### PR DESCRIPTION
Fixes #115.

It looks like TravisCI updated pip from 1.4.1 to 1.5.1 and it changed some default behavior.  In this PR, I add `--allow-all-external` and `--allow-unverified mpi4py` flags to the `mpi4py` line in .travis.yml and it seems to now find a new enough version.  I also remove the now-deprecated --use-mirrors flags.

I played around with using a requirements.txt file in a different branch (https://github.com/enthought/distarray/tree/feature/update-TravisCI-config) but it seemed to cause more problems than it solved.
