### PR TITLE
Add a `coverage combine` before `coverage html`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ test_with_coverage: test_client_with_coverage test_engines_with_coverage
 .PHONY: test_with_coverage
 
 coverage_report:
+	${COVERAGE} combine
 	${COVERAGE} html
 .PHONY: coverage_report
 


### PR DESCRIPTION
Now that we're running coverage with `-p`, we need to run `coverage combine` before making a report.
