### PR TITLE
Add -v option to unittest.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ setup_cluster:
 .PHONY: setup_cluster
 
 test_client:
-	${PYTHON} -m unittest discover
+	${PYTHON} -m unittest discover -v
 .PHONY: test_client
 
 test_client_with_coverage:
-	${COVERAGE} run -pm unittest discover
+	${COVERAGE} run -pm unittest discover -v
 .PHONY: test_client_with_coverage
 
 test_engines:


### PR DESCRIPTION
This PR adds the `-v` verbose option to the unittest commands. I did not do this for the parallel tests.
This will help if the tests hang, as you will have a better idea as to which one went bad.
