### PR TITLE
Correct parallel test division to be integer, not float.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ setup_cluster:
 .PHONY: setup_cluster
 
 test_client:
-	${PYTHON} -m unittest discover -v
+	${PYTHON} -m unittest discover
 .PHONY: test_client
 
 test_client_with_coverage:
-	${COVERAGE} run -pm unittest discover -v
+	${COVERAGE} run -pm unittest discover
 .PHONY: test_client_with_coverage
 
 test_engines:


### PR DESCRIPTION
Some of the parallel tests were using a single slash division to get an expected array size. On Python 3 this resulted in a floating point size which resulted in warning messages. This PR corrects this division to be a double slash.

I'll let Travis test this change for Python 2...
