### PR TITLE
Make testing.py classmethods into attributes.

### DIFF
--- a/distarray/local/tests/paralleltest_distributed_array_protocol.py
+++ b/distarray/local/tests/paralleltest_distributed_array_protocol.py
@@ -155,9 +155,7 @@ class TestDapTwoDistDims(DapTestMixin, MpiTestCase):
 
 class TestDapThreeBlockDims(DapTestMixin, MpiTestCase):
 
-    @classmethod
-    def get_comm_size(cls):
-        return 12
+    comm_size = 12
 
     def setUp(self):
         self.larr = distarray.local.LocalArray((53, 77, 99),
@@ -195,9 +193,7 @@ class TestDapThreeMixedDims(DapTestMixin, MpiTestCase):
 
 class TestDapLopsided(DapTestMixin, MpiTestCase):
 
-    @classmethod
-    def get_comm_size(cls):
-        return 2
+    comm_size = 2
 
     def setUp(self):
         if self.comm.Get_rank() == 0:

--- a/distarray/local/tests/paralleltest_functions.py
+++ b/distarray/local/tests/paralleltest_functions.py
@@ -45,14 +45,14 @@ class TestFunctions(MpiTestCase):
 class TestCreationFuncs(MpiTestCase):
 
     def test_zeros(self):
-        size = self.get_comm_size()
+        size = self.comm_size
         nrows = size * 3
         a = dla.zeros((nrows, 20), comm=self.comm)
         expected = np.zeros((nrows // size, 20))
         assert_array_equal(a.local_array, expected)
 
     def test_ones(self):
-        size = self.get_comm_size()
+        size = self.comm_size
         nrows = size * 3
         a = dla.ones((nrows, 20), comm=self.comm)
         expected = np.ones((nrows // size, 20))

--- a/distarray/local/tests/paralleltest_io.py
+++ b/distarray/local/tests/paralleltest_io.py
@@ -127,9 +127,7 @@ nu_test_data = [
 
 class TestNpyFileLoad(MpiTestCase):
 
-    @classmethod
-    def get_comm_size(self):
-        return 2
+    comm_size = 2
 
     def setUp(self):
         self.rank = self.comm.Get_rank()
@@ -220,9 +218,7 @@ class TestHdf5FileSave(MpiTestCase):
 
 class TestHdf5FileLoad(MpiTestCase):
 
-    @classmethod
-    def get_comm_size(cls):
-        return 2
+    comm_size = 2
 
     def setUp(self):
         self.rank = self.comm.Get_rank()

--- a/distarray/local/tests/paralleltest_localarray.py
+++ b/distarray/local/tests/paralleltest_localarray.py
@@ -182,9 +182,7 @@ class TestFromDimData(MpiTestCase):
 
 class TestGridShape(MpiTestCase):
 
-    @classmethod
-    def get_comm_size(cls):
-        return 12
+    comm_size = 12
 
     def test_grid_shape(self):
         """Test various ways of setting the grid_shape."""
@@ -204,9 +202,7 @@ class TestDistMatrix(MpiTestCase):
 
     """Test the dist_matrix."""
 
-    @classmethod
-    def get_comm_size(cls):
-        return 12
+    comm_size = 12
 
     @unittest.skip("Plot test.")
     def test_plot_dist_matrix(self):

--- a/distarray/testing.py
+++ b/distarray/testing.py
@@ -95,20 +95,19 @@ class MpiTestCase(unittest.TestCase):
 
     """Base test class for MPI test cases.
 
-    Overload `get_comm_size` to change the default comm size (default is 4).
+    Overload the `comm_size` class attribute to change the default
+    (default is 4).
     """
 
-    @classmethod
-    def get_comm_size(cls):
-        return 4
+    comm_size = 4
 
     @classmethod
     def setUpClass(cls):
         try:
-            cls.comm = create_comm_of_size(cls.get_comm_size())
+            cls.comm = create_comm_of_size(cls.comm_size)
         except InvalidCommSizeError:
             msg = "Must run with comm size >= {}."
-            raise unittest.SkipTest(msg.format(cls.get_comm_size()))
+            raise unittest.SkipTest(msg.format(cls.comm_size))
 
     @classmethod
     def tearDownClass(cls):
@@ -120,19 +119,17 @@ class IpclusterTestCase(unittest.TestCase):
 
     """Base test class for test cases needing an ipcluster.
 
-    Overload `get_ipcluster_size` to change the default (default is 4).
+    Overload the `ipcluster_size` class attribute to change the default (default is 4).
     """
 
-    @classmethod
-    def get_ipcluster_size(cls):
-        return 4
+    ipcluster_size = 4
 
     @classmethod
     def setUpClass(cls):
         cls.client = Client()
-        if len(cls.client) < cls.get_ipcluster_size():
+        if len(cls.client) < cls.ipcluster_size:
             errmsg = 'Tests need an ipcluster with at least {} engines running.'
-            raise unittest.SkipTest(errmsg.format(cls.get_ipcluster_size()))
+            raise unittest.SkipTest(errmsg.format(cls.ipcluster_size))
 
     def tearDown(self):
         self.client.clear(block=True)

--- a/distarray/tests/test_distributed_io.py
+++ b/distarray/tests/test_distributed_io.py
@@ -128,9 +128,7 @@ nu_test_data = [
 
 class TestNpyFileLoad(IpclusterTestCase):
 
-    @classmethod
-    def get_ipcluster_size(cls):
-        return 2
+    ipcluster_size = 2
 
     def setUp(self):
         self.dac = Context(self.client, targets=[0, 1])
@@ -230,9 +228,7 @@ class TestHdf5FileSave(IpclusterTestCase):
 
 class TestHdf5FileLoad(IpclusterTestCase):
 
-    @classmethod
-    def get_ipcluster_size(cls):
-        return 2
+    ipcluster_size = 2
 
     def setUp(self):
         self.h5py = import_or_skip('h5py')


### PR DESCRIPTION
There are a couple of classmethods in `testing.py` that should really be class attributes instead.  I fix that in this PR, including updating usage.

`get_ipcluster_size()` -> `ipcluster_size`
`get_comm_size()` -> `comm_size`
