### PR TITLE
Test DAP export with validator.

### DIFF
--- a/distarray/local/tests/paralleltest_distributed_array_protocol.py
+++ b/distarray/local/tests/paralleltest_distributed_array_protocol.py
@@ -18,9 +18,6 @@ from distarray.testing import MpiTestCase, CommNullPasser
 VALID_DIST_TYPES = {'n', 'b', 'c', 'u'}
 
 
-#TODO: Use the validator from the Distributed Array Protocol here
-
-
 @six.add_metaclass(CommNullPasser)
 class DapTestMixin(object):
 


### PR DESCRIPTION
Partially addresses #137.

We could probably incorporate the validator into the main (non-test) code as well, but I think we should wait until @kwmsmith's map PRs are in.
