### PR TITLE
Refactor key-management

### DIFF
--- a/distarray/context.py
+++ b/distarray/context.py
@@ -133,7 +133,7 @@ class Context(object):
         self.targets = [target_from_rank[i] for i in range(len(target_from_rank))]
 
     @staticmethod
-    def _key_basename():
+    def _key_prefix():
         """ Get the base name for all keys. """
         return DISTARRAY_BASE_NAME
 


### PR DESCRIPTION
Objects which contexts create are now put in dictionaries on the engines. This is still a work in progress, but it currently has all tests passing. I still need to alter `decorators.py` to use this properly.
