### PR TITLE
Remove object specific prefixes from keys.

### DIFF
--- a/distarray/context.py
+++ b/distarray/context.py
@@ -143,10 +143,11 @@ class Context(object):
         """ Get the base name for all keys. """
         return DISTARRAY_BASE_NAME
 
-    def uid(self):
+    @staticmethod
+    def uid():
         """Generate a unique valid python name."""
         # Full length seems excessively verbose so use 16 characters.
-        return self._key_prefix() + uuid.uuid4().hex[:16]
+        return Context._key_prefix() + uuid.uuid4().hex[:16]
 
     def _generate_key(self):
         """ Generate a unique key name for this context. """


### PR DESCRIPTION
previously `context`'s dicts on the engines had a `da` between `DISTARRAY_BASE_NAME` and the uid, this is removed. And keys in the dict started with `key_`, now the start with `DISTARRAY_BASE_NAME`.
