### PR TITLE
Adds cleanall makefile target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,5 +91,9 @@ coverage_report:
 clean:
 	-${PYTHON} setup.py clean --all
 	-find . \( -iname '*.py[co]' -or -iname '*.so' -or -iname '__pycache__' \) -exec ${RM} -r '{}' +
-	-${RM} -r ${PARALLEL_OUT_DIR} build MANIFEST dist distarray.egg-info coverage_report
+	-${RM} -r ${PARALLEL_OUT_DIR} build coverage_report
 .PHONY: clean
+
+cleanall: clean
+	-${RM} -r MANIFEST dist distarray.egg-info
+.PHONY: cleanall


### PR DESCRIPTION
`cleanall` wipes everything out.

`clean` just gets rid of temporary stuff, like `pyc`, `pyo`, and `__pycache__` directories, and test results.
