### PR TITLE
Fewer __get/setitem__ roundtrips.

### DIFF
--- a/distarray/dist/distarray.py
+++ b/distarray/dist/distarray.py
@@ -132,8 +132,6 @@ class DistArray(object):
         elif isinstance(index, tuple):
             targets = self.distribution.owning_targets(index)
 
-            # Using a private IPython function is probably a bad think to do.
-            # but its the only apply function that lets us specify `targets`.
             args = (self.key, index)
             result = self.context.apply(getit, args=args,
                                         targets=targets)


### PR DESCRIPTION
Closes #339
Reimplements `DistArray.__get/setitem__` to only use one round trip.
