### PR TITLE
Reduce the number of roundtrips for DistArray.get_localshapes to zero.

### DIFF
--- a/distarray/dist/distarray.py
+++ b/distarray/dist/distarray.py
@@ -23,8 +23,7 @@ import numpy as np
 import distarray
 from distarray.dist.maps import Distribution
 from distarray.utils import _raise_nie
-from distarray.metadata_utils import (normalize_reduction_axes,
-                                      get_shape_from_dim_data_per_rank)
+from distarray.metadata_utils import normalize_reduction_axes
 
 __all__ = ['DistArray']
 
@@ -263,8 +262,9 @@ class DistArray(object):
 
     def _reduce(self, local_reduce_name, axes=None, dtype=None, out=None):
 
-        if any(0 in localshape for localshape in self.get_localshapes()):
-            raise NotImplementedError("Reduction not implemented for empty LocalArrays")
+        if any(0 in localshape for localshape in self.localshapes()):
+            raise NotImplementedError("Reduction not implemented for empty "
+                                      "LocalArrays")
 
         if out is not None:
             _raise_nie()
@@ -339,9 +339,8 @@ class DistArray(object):
             return key.copy()
         return self.context.apply(get, args=(self.key,), targets=self.targets)
 
-    def get_localshapes(self):
-        ddpr = self.distribution.get_dim_data_per_rank()
-        return get_shape_from_dim_data_per_rank(ddpr)
+    def localshapes(self):
+        return self.distribution.localshapes()
 
     # Binary operators
 

--- a/distarray/dist/maps.py
+++ b/distarray/dist/maps.py
@@ -38,7 +38,8 @@ from distarray.metadata_utils import (normalize_dist,
                                       positivify,
                                       _start_stop_block,
                                       normalize_dim_dict,
-                                      normalize_reduction_axes)
+                                      normalize_reduction_axes,
+                                      shapes_from_dim_data_per_rank)
 
 
 def _dedup_dim_dicts(dim_dicts):

--- a/distarray/dist/tests/test_decorators.py
+++ b/distarray/dist/tests/test_decorators.py
@@ -203,7 +203,7 @@ class TestLocalDecorator(ContextTestCase):
         dd = self.local_sum(self.da)
         if self.ntargets == 1:
             dd = [dd]
-        lshapes = self.da.get_localshapes()
+        lshapes = self.da.localshapes()
         expected = []
         for lshape in lshapes:
             expected.append(lshape[0] * lshape[1] * (2 * numpy.pi))
@@ -234,7 +234,7 @@ class TestLocalDecorator(ContextTestCase):
 
     @unittest.skip('Locally adding ndarrays not supported.')
     def test_local_add_ndarray(self):
-        shp = self.da.get_localshapes()[0]
+        shp = self.da.localshapes()[0]
         ndarr = numpy.empty(shp)
         ndarr.fill(33)
         dk = self.local_add_ndarray(self.da, 11, ndarr)

--- a/distarray/dist/tests/test_distarray.py
+++ b/distarray/dist/tests/test_distarray.py
@@ -365,9 +365,10 @@ class TestDistArrayCreationSubSet(ContextTestCase):
     def test_create_target_subset(self):
         shape = (100, 100)
         subtargets = self.context.targets[::2]
-        distribution = Distribution.from_shape(self.context, shape=shape, targets=subtargets)
+        distribution = Distribution.from_shape(self.context, shape=shape,
+                                               targets=subtargets)
         darr = self.context.ones(distribution)
-        lss = darr.get_localshapes()
+        lss = darr.localshapes()
         self.assertEqual(len(lss), len(subtargets))
 
         ddpr = distribution.get_dim_data_per_rank()

--- a/distarray/metadata_utils.py
+++ b/distarray/metadata_utils.py
@@ -354,7 +354,7 @@ def size_chooser(dist_type):
     return chooser[dist_type]
 
 
-def get_shape_from_dim_data_per_rank(ddpr):  # ddpr = dim_data_per_rank
+def shapes_from_dim_data_per_rank(ddpr):  # ddpr = dim_data_per_rank
     """
     Given a dim_data_per_rank object, return the shapes of the localarrays.
     This requires no communication.

--- a/distarray/tests/test_metadata_utils.py
+++ b/distarray/tests/test_metadata_utils.py
@@ -37,7 +37,7 @@ class TestGridSizes(unittest.TestCase):
         dist = Distribution.from_shape(self.context, (2, 3, 4),
                                        dist=('n', 'b', 'c'))
         ddpr = dist.get_dim_data_per_rank()
-        shapes = metadata_utils.get_shape_from_dim_data_per_rank(ddpr)
+        shapes = metadata_utils.shapes_from_dim_data_per_rank(ddpr)
         if len(self.context.view) == 4:
             self.assertEqual(shapes, [(2, 2, 2), (2, 2, 2), (2, 1, 2),
                                       (2, 1, 2)])
@@ -50,7 +50,7 @@ class TestGridSizes(unittest.TestCase):
 
         dist = Distribution(self.context, (dim_dict,))
         ddpr = dist.get_dim_data_per_rank()
-        shapes = metadata_utils.get_shape_from_dim_data_per_rank(ddpr)
+        shapes = metadata_utils.shapes_from_dim_data_per_rank(ddpr)
         self.assertEqual(shapes, [(42,)])
 
     def test_b_size(self):
@@ -63,7 +63,7 @@ class TestGridSizes(unittest.TestCase):
                     'stop': 42}
         dist = Distribution(self.context, (dim_dict,))
         ddpr = dist.get_dim_data_per_rank()
-        shapes = metadata_utils.get_shape_from_dim_data_per_rank(ddpr)
+        shapes = metadata_utils.shapes_from_dim_data_per_rank(ddpr)
         self.assertEqual(shapes, [(20,), (22,)])
 
     def test_c_size(self):
@@ -74,7 +74,7 @@ class TestGridSizes(unittest.TestCase):
                     'start': 0}
         dist = Distribution(self.context, (dim_dict,))
         ddpr = dist.get_dim_data_per_rank()
-        shapes = metadata_utils.get_shape_from_dim_data_per_rank(ddpr)
+        shapes = metadata_utils.shapes_from_dim_data_per_rank(ddpr)
         self.assertEqual(shapes, [(21,), (21,)])
 
     def test_bc_size(self):
@@ -87,7 +87,7 @@ class TestGridSizes(unittest.TestCase):
                     'start': 0}
         dist = Distribution(self.context, (dim_dict,))
         ddpr = dist.get_dim_data_per_rank()
-        shapes = metadata_utils.get_shape_from_dim_data_per_rank(ddpr)
+        shapes = metadata_utils.shapes_from_dim_data_per_rank(ddpr)
         self.assertEqual(shapes, [(20,), (22,)])
 
 


### PR DESCRIPTION
This also adds functions to metadata utils that could be useful for local map construction. But that can wait for another PR.
