### PR TITLE
Fix iopubwatcher to work under Python 3.

### DIFF
--- a/utils/iopubwatcher.py
+++ b/utils/iopubwatcher.py
@@ -67,7 +67,7 @@ def main(connection_file):
         elif msg['msg_type'] == 'pyerr':
             # Python traceback
             c = msg['content']
-            print(topic + ':')
+            print(topic + b':')
             for line in c['traceback']:
                 # indent lines
                 print('    ' + line)


### PR DESCRIPTION
Very small fix.  Previously iopubwatcher would throw an error about concatenating strings to bytes when run on python 3 (and when it tried to report a local error).
