### PR TITLE
More succinct paralleltest test output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ MPIEXEC_ARGS := --output-filename ${MPI_OUT_PREFIX} -n ${NPROCS}
 # PARALLEL_TEST_REGULAR or PARALLEL_TEST_COVERAGE from above.  See the
 # `test_engines` and `test_engines_with_coverage` targets.
 MPI_EXEC_CMD = (${MPIEXEC} ${MPIEXEC_ARGS} ${PARALLEL_TEST} ; OUT=$$? ; \
-			   for f in ${MPI_OUT_PREFIX}* ; do echo "====> " $$f ; cat $$f ; done ; \
+			   for f in ${MPI_OUT_PREFIX}* ; do echo "====> " $$f ; tail -1 $$f ; done ; \
 			   exit $$OUT)
 
 # default number of engines to use.


### PR DESCRIPTION
I've run into problems a few times where the first 1 or 4 parallel engines have errors, but the latter ones don't.  The way the output is ordered, the latter tests make it seem like everything is fine.

This makes the output more compact to give a quick overview of the success or failure of the parallel tests; it is always possible to look at the file in `.parallel_out` for more details.

For example:

```
$ make test_engines
Running 'python -m unittest discover -s distarray/local/tests -p 'paralleltest*.py'' on each engine...
====>  .parallel_out/2.7.3-unittest.out.1.00
OK
====>  .parallel_out/2.7.3-unittest.out.1.01
OK
====>  .parallel_out/2.7.3-unittest.out.1.02
OK
====>  .parallel_out/2.7.3-unittest.out.1.03
OK
====>  .parallel_out/2.7.3-unittest.out.1.04
OK
====>  .parallel_out/2.7.3-unittest.out.1.05
OK
====>  .parallel_out/2.7.3-unittest.out.1.06
OK
====>  .parallel_out/2.7.3-unittest.out.1.07
OK
====>  .parallel_out/2.7.3-unittest.out.1.08
OK
====>  .parallel_out/2.7.3-unittest.out.1.09
OK
====>  .parallel_out/2.7.3-unittest.out.1.10
OK
====>  .parallel_out/2.7.3-unittest.out.1.11
OK
```
