### PR TITLE
Lock version of h5py to 2.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - pip install matplotlib  # for plotting.py
     - pip install mpi4py --allow-all-external --allow-unverified mpi4py
     - pip install cython
-    - CC=mpicc pip install git+https://github.com/h5py/h5py.git --install-option="--mpi"
+    - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.2.1 --install-option="--mpi"
     - pip install sphinx
     - pip install sphinxcontrib-napoleon
     - pip install coverage


### PR DESCRIPTION
Fixes #456.

We can evaluate bumping the version to a more recent release.  This fixes the regression for now.
