### PR TITLE
Use slicing when possible in fromndarray.

### DIFF
--- a/distarray/dist/context.py
+++ b/distarray/dist/context.py
@@ -503,7 +503,7 @@ class Context(object):
             distribution = Distribution.from_shape(self, arr.shape)
         out = self.empty(distribution, dtype=arr.dtype)
         try:
-            out[:] = arr
+            out[...] = arr
         except AttributeError:
             # no slicing for a given map type; do it the slow way
             for index, value in numpy.ndenumerate(arr):


### PR DESCRIPTION
We should probably allow slice syntax for `__setitem__` in all cases and just fall back to an item-by-item implementation when necessary, but that can be a separate PR.

Partially addresses #452.
