### PR TITLE
Update pi-montecarlo example to use `sum` again.

### DIFF
--- a/examples/pi-montecarlo/pi_distarray.py
+++ b/examples/pi-montecarlo/pi_distarray.py
@@ -10,7 +10,7 @@ Usage:
     $ python pi_distarray.py <number of points>
 """
 
-from __future__ import division
+from __future__ import division, print_function
 
 import sys
 
@@ -24,10 +24,6 @@ context = Context()
 random = Random(context)
 
 
-def local_sum(mask):
-    return mask.ndarray.sum()
-
-
 @timer
 def calc_pi(n):
     """Estimate pi using distributed NumPy arrays."""
@@ -36,8 +32,7 @@ def calc_pi(n):
     y = random.rand(distribution)
     r = hypot(x, y)
     mask = (r < 1)
-    lsum = context.apply(local_sum, (mask.key,))
-    return 4 * sum(lsum) / n
+    return 4 * mask.sum().toarray() / n
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now that `sum()` works with boolean arrays again, we can restore the original implementation of the `pi-montecarlo` example and use `sum()` instead of a custom local function.
