### PR TITLE
Make `from_shape` Distribution's default constructor

### DIFF
--- a/distarray/dist/context.py
+++ b/distarray/dist/context.py
@@ -505,7 +505,7 @@ class Context(object):
         ----------
         distribution : Distribution object, optional
             If a Distribution object is not provided, one is created with
-            `Distribution.from_shape(arr.shape)`.
+            `Distribution(arr.shape)`.
 
         Returns
         -------
@@ -514,7 +514,7 @@ class Context(object):
             from `arr`.
         """
         if distribution is None:
-            distribution = Distribution.from_shape(self, arr.shape)
+            distribution = Distribution(self, arr.shape)
         out = self.empty(distribution, dtype=arr.dtype)
         try:
             out[...] = arr
@@ -549,9 +549,9 @@ class Context(object):
 
         dist = kwargs.get('dist', None)
         grid_shape = kwargs.get('grid_shape', None)
-        distribution = Distribution.from_shape(context=self,
-                                               shape=shape, dist=dist,
-                                               grid_shape=grid_shape)
+        distribution = Distribution(context=self,
+                                    shape=shape, dist=dist,
+                                    grid_shape=grid_shape)
         ddpr = distribution.get_dim_data_per_rank()
         da_name = self.apply(_local_fromfunction,
                              (function, distribution.comm, ddpr, kwargs),

--- a/distarray/dist/maps.py
+++ b/distarray/dist/maps.py
@@ -790,11 +790,11 @@ class Distribution(object):
 
         reduced_targets = [self.targets[r] for r in reduced_ranks.flat]
 
-        return Distribution.from_shape(context=self.context,
-                                       shape=reduced_shape,
-                                       dist=reduced_dist,
-                                       grid_shape=reduced_grid_shape,
-                                       targets=reduced_targets)
+        return Distribution(context=self.context,
+                            shape=reduced_shape,
+                            dist=reduced_dist,
+                            grid_shape=reduced_grid_shape,
+                            targets=reduced_targets)
 
     def localshapes(self):
         return shapes_from_dim_data_per_rank(self.get_dim_data_per_rank())

--- a/distarray/dist/tests/test_context.py
+++ b/distarray/dist/tests/test_context.py
@@ -102,25 +102,25 @@ class TestPrimeCluster(ContextTestCase):
     ntargets = 3
 
     def test_1D(self):
-        d = Distribution.from_shape(self.context, (3,))
+        d = Distribution(self.context, (3,))
         a = self.context.empty(d)
         self.assertEqual(a.grid_shape, (3,))
 
     def test_2D(self):
-        da = Distribution.from_shape(self.context, (3, 3))
+        da = Distribution(self.context, (3, 3))
         a = self.context.empty(da)
-        db = Distribution.from_shape(self.context, (3, 3), dist=('n', 'b'))
+        db = Distribution(self.context, (3, 3), dist=('n', 'b'))
         b = self.context.empty(db)
         self.assertEqual(a.grid_shape, (3, 1))
         self.assertEqual(b.grid_shape, (1, 3))
 
     def test_3D(self):
-        da = Distribution.from_shape(self.context, (3, 3, 3))
+        da = Distribution(self.context, (3, 3, 3))
         a = self.context.empty(da)
-        db = Distribution.from_shape(self.context, (3, 3, 3),
+        db = Distribution(self.context, (3, 3, 3),
                                      dist=('n', 'b', 'n'))
         b = self.context.empty(db)
-        dc = Distribution.from_shape(self.context, (3, 3, 3),
+        dc = Distribution(self.context, (3, 3, 3),
                                      dist=('n', 'n', 'b'))
         c = self.context.empty(dc)
         self.assertEqual(a.grid_shape, (3, 1, 1))

--- a/distarray/dist/tests/test_decorators.py
+++ b/distarray/dist/tests/test_decorators.py
@@ -29,7 +29,7 @@ class TestDecoratorBase(TestCase):
     def test_determine_context(self):
         context = Context()
         context2 = Context()  # for cross Context checking
-        distribution = Distribution.from_shape(context, (2, 2))
+        distribution = Distribution(context, (2, 2))
         da = context.ones(distribution)
 
         def dummy_func(*args, **kwargs):
@@ -48,7 +48,7 @@ class TestDecoratorBase(TestCase):
     def test_key_and_push_args(self):
         context = Context()
 
-        distribution = Distribution.from_shape(context, (2, 2))
+        distribution = Distribution(context, (2, 2))
         da = context.ones(distribution)
         db = da*2
 
@@ -147,7 +147,7 @@ class TestLocalDecorator(ContextTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestLocalDecorator, cls).setUpClass()
-        distribution = Distribution.from_shape(cls.context, (5, 5))
+        distribution = Distribution(cls.context, (5, 5))
         cls.da = cls.context.empty(distribution)
         cls.da.fill(2 * numpy.pi)
 
@@ -155,7 +155,7 @@ class TestLocalDecorator(ContextTestCase):
         """Test the @local decorator"""
         context = Context()
 
-        distribution = Distribution.from_shape(context, (4, 4))
+        distribution = Distribution(context, (4, 4))
         da = context.empty(distribution)
         a = numpy.empty((4, 4))
 
@@ -181,8 +181,8 @@ class TestLocalDecorator(ContextTestCase):
 
         ctx1 = Context(targets=range(4))
         ctx2 = Context(targets=range(3))
-        distribution1 = Distribution.from_shape(ctx1, (10,))
-        distribution2 = Distribution.from_shape(ctx2, (10,))
+        distribution1 = Distribution(ctx1, (10,))
+        distribution2 = Distribution(ctx2, (10,))
         da1 = ctx1.ones(distribution1)
         da2 = ctx2.ones(distribution2)
         db1 = self.local_sin(da1)
@@ -219,14 +219,14 @@ class TestLocalDecorator(ContextTestCase):
         self.assert_allclose(df, 2 * numpy.pi + 11 + 12 + 13)
 
     def test_local_add_distarrayproxies(self):
-        distribution = Distribution.from_shape(self.context, (5, 5))
+        distribution = Distribution(self.context, (5, 5))
         dg = self.context.empty(distribution)
         dg.fill(33)
         dh = self.local_add_distarrayproxies(self.da, dg)
         self.assert_allclose(dh, 33 + 2 * numpy.pi)
 
     def test_local_add_mixed(self):
-        distribution = Distribution.from_shape(self.context, (5, 5))
+        distribution = Distribution(self.context, (5, 5))
         di = self.context.empty(distribution)
         di.fill(33)
         dj = self.local_add_mixed(self.da, 11, di, 12)
@@ -245,7 +245,7 @@ class TestLocalDecorator(ContextTestCase):
         self.assert_allclose(dl, 2 * numpy.pi + 11 + 12)
 
     def test_local_add_supermix(self):
-        distribution = Distribution.from_shape(self.context, (5, 5))
+        distribution = Distribution(self.context, (5, 5))
         dm = self.context.empty(distribution)
         dm.fill(22)
         dn = self.context.empty(distribution)

--- a/distarray/dist/tests/test_distarray.py
+++ b/distarray/dist/tests/test_distarray.py
@@ -27,8 +27,7 @@ class TestDistArray(ContextTestCase):
 
     def test_set_and_getitem_block_dist(self):
         size = 10
-        distribution = Distribution.from_shape(self.context, (size,),
-                                               dist={0: 'b'})
+        distribution = Distribution(self.context, (size,), dist={0: 'b'})
         dap = self.context.empty(distribution)
 
         for val in range(size):
@@ -43,8 +42,8 @@ class TestDistArray(ContextTestCase):
 
     def test_set_and_getitem_nd_block_dist(self):
         size = 5
-        distribution = Distribution.from_shape(self.context, (size, size),
-                                               dist={0: 'b', 1: 'b'})
+        distribution = Distribution(self.context, (size, size),
+                                    dist={0: 'b', 1: 'b'})
         dap = self.context.empty(distribution)
 
         for row in range(size):
@@ -60,8 +59,8 @@ class TestDistArray(ContextTestCase):
 
     def test_set_and_getitem_cyclic_dist(self):
         size = 10
-        distribution = Distribution.from_shape(self.context, (size,),
-                                               dist={0: 'c'})
+        distribution = Distribution(self.context, (size,),
+                                    dist={0: 'c'})
         dap = self.context.empty(distribution)
 
         for val in range(size):
@@ -73,7 +72,7 @@ class TestDistArray(ContextTestCase):
             self.assertEqual(dap[-i], i)
 
     def test_get_index_error(self):
-        distribution = Distribution.from_shape(self.context, (10,), dist={0: 'c'})
+        distribution = Distribution(self.context, (10,), dist={0: 'c'})
         dap = self.context.empty(distribution)
         with self.assertRaises(IndexError):
             dap[11]
@@ -81,7 +80,7 @@ class TestDistArray(ContextTestCase):
             dap[-11]
 
     def test_set_index_error(self):
-        distribution = Distribution.from_shape(self.context, (10,), dist={0: 'c'})
+        distribution = Distribution(self.context, (10,), dist={0: 'c'})
         dap = self.context.empty(distribution)
         with self.assertRaises(IndexError):
             dap[11] = 55
@@ -90,15 +89,14 @@ class TestDistArray(ContextTestCase):
 
     def test_iteration(self):
         size = 10
-        distribution = Distribution.from_shape(self.context, (size,),
-                                               dist={0: 'c'})
+        distribution = Distribution(self.context, (size,), dist={0: 'c'})
         dap = self.context.empty(distribution)
         dap.fill(10)
         for val in dap:
             self.assertEqual(val, 10)
 
     def test_tondarray(self):
-        distribution = Distribution.from_shape(self.context, (3, 3))
+        distribution = Distribution(self.context, (3, 3))
         dap = self.context.empty(distribution)
         ndarr = numpy.arange(9).reshape(3, 3)
         for (i, j), val in numpy.ndenumerate(ndarr):
@@ -106,28 +104,28 @@ class TestDistArray(ContextTestCase):
         numpy.testing.assert_array_equal(dap.tondarray(), ndarr)
 
     def test__array_interface(self):
-        distribution = Distribution.from_shape(self.context, (7, 9))
+        distribution = Distribution(self.context, (7, 9))
         darr = self.context.ones(distribution)
         nparr = numpy.array(darr)
         assert_array_equal(darr.tondarray(), nparr)
         assert_array_equal(numpy.ones((7, 9)), nparr)
 
     def test_set_numpy_array_full_slice_with_distarray(self):
-        distribution = Distribution.from_shape(self.context, (7, 9))
+        distribution = Distribution(self.context, (7, 9))
         darr = self.context.ones(distribution)
         nparr = numpy.zeros_like(darr)
         nparr[...] = darr
         assert_array_equal(nparr, darr.toarray())
 
     def test_set_numpy_array_partial_slice_with_distarray(self):
-        distribution = Distribution.from_shape(self.context, (15, 4))
+        distribution = Distribution(self.context, (15, 4))
         darr = self.context.ones(distribution)
         nparr = numpy.zeros_like(darr)
         nparr[3, :] = darr[3, :]
         assert_array_equal(nparr[3, :], darr[3, :].toarray())
 
     def test_set_numpy_array_partial_slice_with_distarray_2(self):
-        distribution = Distribution.from_shape(self.context, (13, 17))
+        distribution = Distribution(self.context, (13, 17))
         darr = self.context.ones(distribution)
         nparr = numpy.zeros((20, 20))
         nparr[:13, :17] = darr
@@ -135,8 +133,7 @@ class TestDistArray(ContextTestCase):
 
     def test_global_tolocal_bug(self):
         # gh-issue #154
-        distribution = Distribution.from_shape(self.context, (3, 3),
-                                               dist=('n', 'b'))
+        distribution = Distribution(self.context, (3, 3), dist=('n', 'b'))
         dap = self.context.zeros(distribution)
         ndarr = numpy.zeros((3, 3))
         numpy.testing.assert_array_equal(dap.tondarray(), ndarr)
@@ -280,7 +277,7 @@ class TestGetItemSlicing(ContextTestCase):
                            expected[..., ..., ..., ...])
 
     def test_resulting_slice(self):
-        dist = Distribution.from_shape(self.context, (10, 20))
+        dist = Distribution(self.context, (10, 20))
         da = self.context.ones(dist)
         db = da[:5, :10]
         dc = db * 2
@@ -420,7 +417,7 @@ class TestSetItemSlicing(ContextTestCase):
             arr[slc] = new_data
 
     def test_set_DistArray_slice(self):
-        dist = Distribution.from_shape(self.context, (10, 20))
+        dist = Distribution(self.context, (10, 20))
         da = self.context.ones(dist)
         db = self.context.zeros(dist)
         da[...] = db
@@ -636,7 +633,7 @@ class TestDistArrayCreation(ContextTestCase):
 
     def test___init__(self):
         shape = (5, 5)
-        distribution = Distribution.from_shape(self.context, shape, ('b', 'c'))
+        distribution = Distribution(self.context, shape, ('b', 'c'))
         da = DistArray(distribution, dtype=int)
         da.fill(42)
         nda = numpy.empty(shape, dtype=int)
@@ -645,41 +642,41 @@ class TestDistArrayCreation(ContextTestCase):
 
     def test_zeros(self):
         shape = (16, 16)
-        distribution = Distribution.from_shape(self.context, shape)
+        distribution = Distribution(self.context, shape)
         zero_distarray = self.context.zeros(distribution)
         zero_ndarray = numpy.zeros(shape)
         assert_array_equal(zero_distarray.tondarray(), zero_ndarray)
 
     def test_zeros_0d(self):
         shape = ()
-        distribution = Distribution.from_shape(self.context, shape)
+        distribution = Distribution(self.context, shape)
         zero_distarray = self.context.zeros(distribution)
         zero_ndarray = numpy.zeros(shape)
         assert_array_equal(zero_distarray.tondarray(), zero_ndarray)
 
     def test_ones(self):
         shape = (16, 16)
-        distribution = Distribution.from_shape(self.context, shape)
+        distribution = Distribution(self.context, shape)
         ones_distarray = self.context.ones(distribution)
         ones_ndarray = numpy.ones(shape)
         assert_array_equal(ones_distarray.tondarray(), ones_ndarray)
 
     def test_ones_0d(self):
         shape = ()
-        distribution = Distribution.from_shape(self.context, shape)
+        distribution = Distribution(self.context, shape)
         ones_distarray = self.context.ones(distribution)
         ones_ndarray = numpy.ones(shape)
         assert_array_equal(ones_distarray.tondarray(), ones_ndarray)
 
     def test_empty(self):
         shape = (16, 16)
-        distribution = Distribution.from_shape(self.context, shape)
+        distribution = Distribution(self.context, shape)
         empty_distarray = self.context.empty(distribution)
         self.assertEqual(empty_distarray.shape, distribution.shape)
 
     def test_empty_0d(self):
         shape = ()
-        distribution = Distribution.from_shape(self.context, shape)
+        distribution = Distribution(self.context, shape)
         empty_distarray = self.context.empty(distribution)
         self.assertEqual(empty_distarray.shape, distribution.shape)
 
@@ -696,7 +693,7 @@ class TestDistArrayCreation(ContextTestCase):
 
     def test_grid_rank(self):
         # regression test for issue #235
-        d = Distribution.from_shape(self.context, (4, 4, 4),
+        d = Distribution(self.context, (4, 4, 4),
                                     dist=('b', 'n', 'b'),
                                     grid_shape=(1, 1, 4))
         a = self.context.empty(d)
@@ -715,8 +712,8 @@ class TestDistArrayCreationSubSet(ContextTestCase):
     def test_create_target_subset(self):
         shape = (100, 100)
         subtargets = self.context.targets[::2]
-        distribution = Distribution.from_shape(self.context, shape=shape,
-                                               targets=subtargets)
+        distribution = Distribution(self.context, shape=shape,
+                                    targets=subtargets)
         darr = self.context.ones(distribution)
         lss = darr.localshapes()
         self.assertEqual(len(lss), len(subtargets))
@@ -732,8 +729,7 @@ class TestReduceMethods(ContextTestCase):
     def setUpClass(cls):
         super(TestReduceMethods, cls).setUpClass()
         cls.arr = numpy.arange(16).reshape(4, 4)
-        dist = Distribution.from_shape(cls.context,
-                                       cls.arr.shape, ('b', 'b'), (2, 2))
+        dist = Distribution(cls.context, cls.arr.shape, ('b', 'b'), (2, 2))
         cls.darr = cls.context.fromndarray(cls.arr, dist)
 
     def test_sum_last_axis(self):
@@ -876,9 +872,8 @@ class TestReduceMethods(ContextTestCase):
         shape = (10, 20, 30, 40)
         arr = numpy.zeros(shape)
         arr.fill(3)
-        dist = Distribution.from_shape(self.context,
-                                       shape=shape,
-                                       dist=('c', 'c', 'c', 'c'))
+        dist = Distribution(self.context, shape=shape,
+                            dist=('c', 'c', 'c', 'c'))
         darr = self.context.empty(distribution=dist)
         darr.fill(3)
         for axis in range(4):
@@ -888,8 +883,8 @@ class TestReduceMethods(ContextTestCase):
         assert_allclose(darr.sum().tondarray(), arr.sum())
 
     def test_gh_435_regression_with_var(self):
-        dist = Distribution.from_shape(self.context, shape=(14,), dist=('b'),
-                                       targets=range(4))
+        dist = Distribution(self.context, shape=(14,), dist=('b'),
+                            targets=range(4))
         darr = self.context.ones(dist)
         darr.var()
 
@@ -910,7 +905,7 @@ class TestFromLocalArrays(ContextTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestFromLocalArrays, cls).setUpClass()
-        cls.distribution = Distribution.from_shape((4, 4))
+        cls.distribution = Distribution((4, 4))
         cls.distarray = cls.context.ones(cls.distribution, dtype=int)
         cls.expected = numpy.ones((4, 4), dtype=int)
 

--- a/distarray/dist/tests/test_distributed_io.py
+++ b/distarray/dist/tests/test_distributed_io.py
@@ -41,8 +41,7 @@ class TestDnpyFileIO(ContextTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestDnpyFileIO, cls).setUpClass()
-        cls.distribution = Distribution.from_shape(cls.context, (100,),
-                                                   dist={0: 'b'})
+        cls.distribution = Distribution(cls.context, (100,), dist={0: 'b'})
         cls.da = cls.context.empty(cls.distribution)
         cls.output_paths = cls.context.apply(engine_temp_path)
 
@@ -242,7 +241,7 @@ class TestHdf5FileSave(ContextTestCase):
         expected = np.random.random(shape)
 
         dist = {0: 'b', 1: 'c', 2: 'n'}
-        distribution = Distribution.from_shape(self.context, shape, dist=dist)
+        distribution = Distribution(self.context, shape, dist=dist)
         da = self.context.fromarray(expected, distribution=distribution)
 
         self.context.save_hdf5(self.output_path, da, mode='w')

--- a/distarray/dist/tests/test_maps.py
+++ b/distarray/dist/tests/test_maps.py
@@ -19,10 +19,7 @@ class TestClientMap(ContextTestCase):
 
     def test_2D_bn(self):
         nrows, ncols = 31, 53
-        cm = Distribution.from_shape(self.context,
-                                     (nrows, ncols),
-                                     {0: 'b'},
-                                     (4, 1))
+        cm = Distribution(self.context, (nrows, ncols), {0: 'b'}, (4, 1))
         chunksize = (nrows // 4) + 1
         for _ in range(100):
             r, c = randrange(nrows), randrange(ncols)
@@ -32,10 +29,8 @@ class TestClientMap(ContextTestCase):
     def test_2D_bb(self):
         nrows, ncols = 3, 5
         nprocs_per_dim = 2
-        cm = Distribution.from_shape(self.context,
-                                     (nrows, ncols),
-                                     ('b', 'b'),
-                                     (nprocs_per_dim, nprocs_per_dim))
+        cm = Distribution(self.context, (nrows, ncols), ('b', 'b'),
+                          (nprocs_per_dim, nprocs_per_dim))
         row_chunks = nrows // nprocs_per_dim + 1
         col_chunks = ncols // nprocs_per_dim + 1
         for r in range(nrows):
@@ -47,10 +42,8 @@ class TestClientMap(ContextTestCase):
     def test_2D_cc(self):
         nrows, ncols = 3, 5
         nprocs_per_dim = 2
-        cm = Distribution.from_shape(self.context,
-                                     (nrows, ncols),
-                                     ('c', 'c'),
-                                     (nprocs_per_dim, nprocs_per_dim))
+        cm = Distribution(self.context, (nrows, ncols), ('c', 'c'),
+                          (nprocs_per_dim, nprocs_per_dim))
         for r in range(nrows):
             for c in range(ncols):
                 rank = ((r % nprocs_per_dim) * nprocs_per_dim
@@ -61,14 +54,10 @@ class TestClientMap(ContextTestCase):
     def test_is_compatible(self):
         nr, nc, nd = 10**5, 10**6, 10**4
 
-        cm0 = Distribution.from_shape(self.context,
-                                      (nr, nc, nd),
-                                      ('b', 'c', 'n'))
+        cm0 = Distribution(self.context, (nr, nc, nd), ('b', 'c', 'n'))
         self.assertTrue(cm0.is_compatible(cm0))
 
-        cm1 = Distribution.from_shape(self.context,
-                                      (nr, nc, nd),
-                                      ('b', 'c', 'n'))
+        cm1 = Distribution(self.context, (nr, nc, nd), ('b', 'c', 'n'))
         self.assertTrue(cm1.is_compatible(cm1))
 
         self.assertTrue(cm0.is_compatible(cm1))
@@ -76,39 +65,25 @@ class TestClientMap(ContextTestCase):
 
         nr -= 1; nc -= 1; nd -= 1
 
-        cm2 = Distribution.from_shape(self.context,
-                                      (nr, nc, nd),
-                                      ('b', 'c', 'n'))
+        cm2 = Distribution(self.context, (nr, nc, nd), ('b', 'c', 'n'))
 
         self.assertFalse(cm1.is_compatible(cm2))
         self.assertFalse(cm2.is_compatible(cm1))
 
     def test_is_compatible_nodist(self):
         # See GH issue #461.
-        dist_bcn = Distribution.from_shape(self.context,
-                                           (10, 10, 10),
-                                           ('b', 'c', 'n'),
-                                           (1,   1,   1),
-                                           targets=[0])
-        dist_nnn = Distribution.from_shape(self.context,
-                                           (10, 10, 10),
-                                           ('n', 'n', 'n'),
-                                           (1,   1,   1),
-                                           targets=[0])
+        dist_bcn = Distribution(self.context, (10, 10, 10), ('b', 'c', 'n'),
+                                (1,   1,   1), targets=[0])
+        dist_nnn = Distribution(self.context, (10, 10, 10), ('n', 'n', 'n'),
+                                (1,   1,   1), targets=[0])
         self.assertTrue(dist_bcn.is_compatible(dist_nnn))
         self.assertTrue(dist_nnn.is_compatible(dist_bcn))
 
     def test_is_compatible_degenerate(self):
-        dist_bc = Distribution.from_shape(self.context,
-                                          (10, 10),
-                                          ('b', 'c'),
-                                          (1,   1),
-                                          targets=[0])
-        dist_cb = Distribution.from_shape(self.context,
-                                           (10, 10),
-                                           ('c', 'b'),
-                                           (1,   1),
-                                           targets=[0])
+        dist_bc = Distribution(self.context, (10, 10), ('b', 'c'), (1,   1),
+                               targets=[0])
+        dist_cb = Distribution(self.context, (10, 10), ('c', 'b'), (1,   1),
+                               targets=[0])
         self.assertTrue(dist_bc.is_compatible(dist_cb))
         self.assertTrue(dist_cb.is_compatible(dist_bc))
 
@@ -150,27 +125,20 @@ class TestClientMap(ContextTestCase):
         self.assertTrue(dist_cyclic.is_compatible(dist_block_cyclic))
 
     def test_not_compatible(self):
-        dist_b1 = Distribution.from_shape(self.context,
-                                          (10,), ('b',),
-                                          (1,), targets=[0])
-
-        dist_b2 = Distribution.from_shape(self.context,
-                                          (9,), ('b',),
-                                          (1,), targets=[0])
+        dist_b1 = Distribution(self.context, (10,), ('b',), (1,), targets=[0])
+        dist_b2 = Distribution(self.context, (9,), ('b',), (1,), targets=[0])
 
         self.assertFalse(dist_b1.is_compatible(dist_b2))
         self.assertFalse(dist_b2.is_compatible(dist_b1))
 
-        dist_b3 = Distribution.from_shape(self.context,
-                                          (10,), ('b',),
-                                          (2,), targets=[0,1])
+        dist_b3 = Distribution(self.context, (10,), ('b',), (2,),
+                               targets=[0,1])
 
         self.assertFalse(dist_b1.is_compatible(dist_b3))
         self.assertFalse(dist_b3.is_compatible(dist_b1))
 
-        dist_b4 = Distribution.from_shape(self.context,
-                                          (10,), ('c',),
-                                          (2,), targets=[0,1])
+        dist_b4 = Distribution(self.context, (10,), ('c',), (2,),
+                               targets=[0,1])
 
         self.assertFalse(dist_b4.is_compatible(dist_b3))
         self.assertFalse(dist_b3.is_compatible(dist_b4))
@@ -190,10 +158,8 @@ class TestClientMap(ContextTestCase):
     def test_reduce(self):
         nr, nc, nd = 10**5, 10**6, 10**4
 
-        dist = Distribution.from_shape(self.context,
-                                       (nr, nc, nd),
-                                       ('b', 'c', 'n'),
-                                       grid_shape=(2, 2, 1))
+        dist = Distribution(self.context, (nr, nc, nd), ('b', 'c', 'n'),
+                            grid_shape=(2, 2, 1))
 
         new_dist0 = dist.reduce(axes=[0])
         self.assertEqual(new_dist0.dist, ('c', 'n'))
@@ -216,7 +182,7 @@ class TestClientMap(ContextTestCase):
 
     def test_reduce_0D(self):
         N = 10**5
-        dist = Distribution.from_shape(self.context, (N,))
+        dist = Distribution(self.context, (N,))
         new_dist = dist.reduce(axes=[0])
         self.assertEqual(new_dist.dist, ())
         self.assertSequenceEqual(new_dist.shape, ())
@@ -227,7 +193,7 @@ class TestClientMap(ContextTestCase):
 class TestSlice(ContextTestCase):
 
     def test_from_partial_slice_1d(self):
-        d0 = Distribution.from_shape(context=self.context, shape=(15,))
+        d0 = Distribution(context=self.context, shape=(15,))
 
         s = (slice(0, 3),)
         d1 = d0.slice(s)
@@ -238,7 +204,7 @@ class TestSlice(ContextTestCase):
         self.assertSequenceEqual(d1.shape, (3,))
 
     def test_from_full_slice_1d(self):
-        d0 = Distribution.from_shape(context=self.context, shape=(15,))
+        d0 = Distribution(context=self.context, shape=(15,))
 
         s = (slice(None),)
         d1 = d0.slice(s)
@@ -249,7 +215,7 @@ class TestSlice(ContextTestCase):
         self.assertSequenceEqual(d1.maps[0].bounds, d0.maps[0].bounds)
 
     def test_from_full_slice_with_step_1d_0(self):
-        d0 = Distribution.from_shape(context=self.context, shape=(15,))
+        d0 = Distribution(context=self.context, shape=(15,))
 
         s = (slice(None, None, 2),)
         d1 = d0.slice(s)
@@ -260,7 +226,7 @@ class TestSlice(ContextTestCase):
         self.assertEqual(d1.maps[0].bounds[0][0], d0.maps[0].bounds[0][0])
 
     def test_from_full_slice_with_step_1d_1(self):
-        d0 = Distribution.from_shape(context=self.context, shape=(30,))
+        d0 = Distribution(context=self.context, shape=(30,))
         step = 4
 
         s = (slice(4, None, step),)
@@ -272,7 +238,7 @@ class TestSlice(ContextTestCase):
         self.assertEqual(d1.maps[0].bounds[0][0], d0.maps[0].bounds[0][0])
 
     def test_from_full_slice_2d(self):
-        d0 = Distribution.from_shape(context=self.context, shape=(15, 20))
+        d0 = Distribution(context=self.context, shape=(15, 20))
 
         s = (slice(None), slice(None))
         d1 = d0.slice(s)
@@ -285,7 +251,7 @@ class TestSlice(ContextTestCase):
         self.assertSequenceEqual(d1.targets, d0.targets)
 
     def test_from_partial_slice_2d(self):
-        d0 = Distribution.from_shape(context=self.context, shape=(15, 20))
+        d0 = Distribution(context=self.context, shape=(15, 20))
 
         s = (slice(3, 7), 4)
         d1 = d0.slice(s)
@@ -296,7 +262,7 @@ class TestSlice(ContextTestCase):
             self.assertSequenceEqual(m.bounds, expected)
 
     def test_full_slice_with_int_2d(self):
-        d0 = Distribution.from_shape(context=self.context, shape=(15, 20))
+        d0 = Distribution(context=self.context, shape=(15, 20))
 
         s = (slice(None), 4)
         d1 = d0.slice(s)
@@ -312,7 +278,7 @@ class TestDunderMethods(ContextTestCase):
     def setUpClass(cls):
         super(TestDunderMethods, cls).setUpClass()
         cls.shape = (3, 4, 5, 6)
-        cls.cm = Distribution.from_shape(cls.context, cls.shape)
+        cls.cm = Distribution(cls.context, cls.shape)
 
     def test___len__(self):
         self.assertEqual(len(self.cm), 4)
@@ -329,9 +295,8 @@ class TestDunderMethods(ContextTestCase):
 
 class TestDistributionCreation(ContextTestCase):
     def test_all_n_dist(self):
-        distribution = Distribution.from_shape(self.context,
-                                               shape=(3, 3),
-                                               dist=('n', 'n'))
+        distribution = Distribution(self.context, shape=(3, 3),
+                                    dist=('n', 'n'))
         self.context.ones(distribution)
 
 

--- a/distarray/dist/tests/test_random.py
+++ b/distarray/dist/tests/test_random.py
@@ -28,37 +28,33 @@ class TestRandom(ContextTestCase):
 
     def test_rand(self):
         shape = (3, 4)
-        distribution = Distribution.from_shape(context=self.context,
-                                               shape=shape)
+        distribution = Distribution(context=self.context, shape=shape)
         a = self.random.rand(distribution)
         self.assertEqual(a.shape, shape)
 
     def test_normal(self):
         shape = (3, 4)  # aka shape
-        distribution = Distribution.from_shape(context=self.context,
-                                               shape=shape)
+        distribution = Distribution(context=self.context, shape=shape)
         a = self.random.normal(distribution)
         self.assertEqual(a.shape, shape)
 
     def test_randint(self):
         low = 1
         shape = (3, 4)  # aka shape
-        distribution = Distribution.from_shape(context=self.context,
-                                               shape=shape)
+        distribution = Distribution(context=self.context, shape=shape)
         a = self.random.randint(distribution, low=low)
         self.assertEqual(a.shape, shape)
 
     def test_randn(self):
         shape = (3, 4)
-        distribution = Distribution.from_shape(context=self.context,
-                                               shape=shape)
+        distribution = Distribution(context=self.context, shape=shape)
         a = self.random.randn(distribution)
         self.assertEqual(a.shape, shape)
 
     def test_seed_same(self):
         """ Test that the same seed generates the same sequence. """
         shape = (8, 6)
-        distribution = Distribution.from_shape(self.context, shape)
+        distribution = Distribution(self.context, shape)
         seed = 0xfeedbeef
         # Seed and get some random numbers.
         self.random.seed(seed)
@@ -76,7 +72,7 @@ class TestRandom(ContextTestCase):
         shape = (8, 6)
         # Seed and get some random numbers.
         self.random.seed(None)
-        d = Distribution.from_shape(self.context, shape)
+        d = Distribution(self.context, shape)
         a = self.random.rand(d)
         aa = a.toarray()
         # Seed again and get more random numbers.
@@ -95,9 +91,8 @@ class TestRandom(ContextTestCase):
             """
             num_engines = len(context.targets)
             shape = (num_engines, num_cols)
-            distribution = Distribution.from_shape(self.context,
-                                                   shape=shape,
-                                                   dist={0: 'b', 1: 'n'})
+            distribution = Distribution(self.context, shape=shape,
+                                        dist={0: 'b', 1: 'n'})
             darr = self.random.rand(distribution)
             return darr
 

--- a/distarray/tests/test_metadata_utils.py
+++ b/distarray/tests/test_metadata_utils.py
@@ -222,8 +222,7 @@ class TestGridSizes(unittest.TestCase):
         cls.context = Context()
 
     def test_dist_sizes(self):
-        dist = Distribution.from_shape(self.context, (2, 3, 4),
-                                       dist=('n', 'b', 'c'))
+        dist = Distribution(self.context, (2, 3, 4), dist=('n', 'b', 'c'))
         ddpr = dist.get_dim_data_per_rank()
         shapes = metadata_utils.shapes_from_dim_data_per_rank(ddpr)
         if len(self.context.view) == 4:

--- a/distarray/tests/test_plotting.py
+++ b/distarray/tests/test_plotting.py
@@ -32,7 +32,7 @@ class TestPlotting(ContextTestCase):
         # (because matplotlib isn't installed, probably)
         cls.plt = import_or_skip("distarray.plotting")
         super(TestPlotting, cls).setUpClass()
-        cls.da = Distribution.from_shape(cls.context, (64, 64))
+        cls.da = Distribution(cls.context, (64, 64))
         cls.arr = cls.context.ones(cls.da)
 
     def test_plot_array_distribution(self):

--- a/examples/basic_demo.py
+++ b/examples/basic_demo.py
@@ -41,7 +41,7 @@ def global_sum(da):
     global_sum = da.distribution.comm.allreduce(local_sum, None, op=MPI.SUM)
 
     new_arr = numpy.array([global_sum])
-    distribution = Distribution.from_shape((1,), comm=da.comm)
+    distribution = Distribution((1,), comm=da.comm)
     new_distarray = LocalArray(distribution, buf=new_arr)
     return new_distarray
 
@@ -52,9 +52,9 @@ if __name__ == '__main__':
 
     print()
     input("Basic creation:")
-    dist_b = Distribution.from_shape(context, (arr_len,), dist={0: 'b'})
+    dist_b = Distribution(context, (arr_len,), dist={0: 'b'})
     dap_b = context.empty(dist_b)
-    dist_c = Distribution.from_shape(context, (arr_len,), dist={0: 'c'})
+    dist_c = Distribution(context, (arr_len,), dist={0: 'c'})
     dap_c = context.empty(dist_c)
     print("dap_b is a ", type(dap_b))
     print("dap_c is a ", type(dap_c))

--- a/examples/features.ipynb
+++ b/examples/features.ipynb
@@ -571,7 +571,7 @@
      "input": [
       "# the above is the default, you can make more complex distributions\n",
       "from distarray.dist import Distribution\n",
-      "distribution = Distribution.from_shape(context, (64, 64), dist=('b', 'c'))\n",
+      "distribution = Distribution(context, (64, 64), dist=('b', 'c'))\n",
       "a = context.zeros(distribution, dtype='int32')\n",
       "plot_array_distribution(a, process_coords, cell_label=False, legend=True)"
      ],
@@ -658,7 +658,7 @@
      "input": [
       "# load .npy files in parallel\n",
       "numpy.save(\"/tmp/outfile.npy\", nparr)\n",
-      "distribution = Distribution.from_shape(context, nparr.shape) \n",
+      "distribution = Distribution(context, nparr.shape) \n",
       "new_darr = context.load_npy(\"/tmp/outfile.npy\", distribution)\n",
       "new_darr"
      ],

--- a/examples/julia-set/bench_dist.py
+++ b/examples/julia-set/bench_dist.py
@@ -24,9 +24,8 @@ from distarray.dist.decorators import local, vectorize
 # Make an empty distributed array
 def make_empty_da(resolution, dist, context):
     """Create the arr we will build the fractal with."""
-    distribution = Distribution.from_shape(context,
-                                           (resolution[0], resolution[1]),
-                                           dist=dist)
+    distribution = Distribution(context, (resolution[0], resolution[1]),
+                                dist=dist)
     out = context.empty(distribution, dtype=complex)
     return out
 

--- a/examples/julia-set/julia_distarray.py
+++ b/examples/julia-set/julia_distarray.py
@@ -26,9 +26,8 @@ with context.view.sync_imports():
 def make_empty_da(resolution, dist):
     """Create the arr we will build the fractal with."""
 
-    distribution = Distribution.from_shape(context,
-                                           (resolution[0], resolution[1]),
-                                           dist=dist)
+    distribution = Distribution(context, (resolution[0], resolution[1]),
+                                dist=dist)
     out = context.empty(distribution, dtype=complex)
     return out
 

--- a/examples/make_distarray.py
+++ b/examples/make_distarray.py
@@ -12,5 +12,5 @@ from distarray.dist import Context, Distribution
 
 
 c = Context()
-d = Distribution.from_shape(c, (10, 10, 10), dist=('b', 'n', 'c'))
+d = Distribution(c, (10, 10, 10), dist=('b', 'n', 'c'))
 a = c.zeros(d, dtype='int32')

--- a/examples/pi-montecarlo/pi_distarray.py
+++ b/examples/pi-montecarlo/pi_distarray.py
@@ -27,7 +27,7 @@ random = Random(context)
 @timer
 def calc_pi(n):
     """Estimate pi using distributed NumPy arrays."""
-    distribution = Distribution.from_shape(context=context, shape=(n,))
+    distribution = Distribution(context=context, shape=(n,))
     x = random.rand(distribution)
     y = random.rand(distribution)
     r = hypot(x, y)

--- a/examples/plot_distarray_block_axis_0.py
+++ b/examples/plot_distarray_block_axis_0.py
@@ -16,7 +16,7 @@ from distarray.dist import Context, Distribution
 
 
 c = Context()
-d = Distribution.from_shape(c, (64, 64))
+d = Distribution(c, (64, 64))
 a = c.zeros(d)
 process_coords = [(0, 0), (1, 0), (2, 0), (3, 0)]
 plotting.plot_array_distribution(a, process_coords, cell_label=False,

--- a/examples/plot_distarray_block_axis_1.py
+++ b/examples/plot_distarray_block_axis_1.py
@@ -15,7 +15,7 @@ from distarray.dist import Context, Distribution
 
 
 c = Context()
-d = Distribution.from_shape(c, (64, 64), dist=('n', 'b'))
+d = Distribution(c, (64, 64), dist=('n', 'b'))
 a = c.zeros(d, dtype='int32')
 process_coords = [(0, 0), (1, 0), (2, 0), (3, 0)]
 plotting.plot_array_distribution(a, process_coords, cell_label=False,

--- a/examples/plot_distarray_block_block.py
+++ b/examples/plot_distarray_block_block.py
@@ -15,7 +15,7 @@ from distarray.dist import Context, Distribution
 
 
 c = Context()
-d = Distribution.from_shape(c, (64, 64), dist=('b', 'b'))
+d = Distribution(c, (64, 64), dist=('b', 'b'))
 a = c.zeros(d, dtype='int32')
 process_coords = [(0, 0), (0, 1), (1, 0), (1, 1)]
 plotting.plot_array_distribution(a, process_coords, cell_label=False,

--- a/examples/plot_distarray_block_cyclic.py
+++ b/examples/plot_distarray_block_cyclic.py
@@ -15,7 +15,7 @@ from distarray.dist import Context, Distribution
 
 
 c = Context()
-d = Distribution.from_shape(c, (64, 64), dist=('b', 'c'))
+d = Distribution(c, (64, 64), dist=('b', 'c'))
 a = c.zeros(d, dtype='int32')
 process_coords = [(0, 0), (0, 1), (1, 0), (1, 1)]
 plotting.plot_array_distribution(a, process_coords, cell_label=False,

--- a/examples/plot_distarray_cyclic_cyclic.py
+++ b/examples/plot_distarray_cyclic_cyclic.py
@@ -15,7 +15,7 @@ from distarray.dist import Context, Distribution
 
 
 c = Context()
-d = Distribution.from_shape(c, (64, 64), dist=('c', 'c'))
+d = Distribution(c, (64, 64), dist=('c', 'c'))
 a = c.zeros(d, dtype='int32')
 process_coords = [(0, 0), (0, 1), (1, 0), (1, 1)]
 plotting.plot_array_distribution(a, process_coords, cell_label=False,

--- a/examples/plot_distarray_protocol.py
+++ b/examples/plot_distarray_protocol.py
@@ -200,7 +200,7 @@ def print_array_documentation(context,
     db_buffer = [a['db_buffer'] for a in attrs]
     db_dim_data = [a['db_dim_data'] for a in attrs]
     db_coords = [a['db_coords'] for a in attrs]
-                    
+
     # Get local ndarrays.
     db_ndarrays = array.get_ndarrays()
 
@@ -304,8 +304,8 @@ def create_distribution_plot_and_documentation(context, params):
 
     # Create array, either from dist or dimdata.
     if dist is not None:
-        distribution = Distribution.from_shape(context, shape, dist=dist,
-                                               grid_shape=grid_shape)
+        distribution = Distribution(context, shape, dist=dist,
+                                    grid_shape=grid_shape)
     elif dimdata is not None:
         distribution = Distribution.from_global_dim_data(context, dimdata)
     else:


### PR DESCRIPTION
1. Rename `Distribution.__new__` -> `Distribution.from_global_dim_data`
2. Rename `Distribution.from_shape` -> `Distribution.__new__`
