### PR TITLE
Slicing a `Map` returns a `Map`

### DIFF
--- a/distarray/dist/maps.py
+++ b/distarray/dist/maps.py
@@ -349,7 +349,7 @@ class BlockMap(MapBase):
         for proc_start, proc_stop in self.bounds:
             stop = idx.stop if idx.stop is not None else proc_stop
             isection = tuple_intersection((start, stop, step),
-                                              (proc_start, proc_stop))
+                                          (proc_start, proc_stop))
             if isection:
                 isection_size = int(np.ceil((isection[1] - (isection[0])) / step))
                 new_bounds.append(isection_size + new_bounds[-1])


### PR DESCRIPTION
Previously there was not a `Distribution` constructor that could take a sequence of `Map`s, so `Map.slice` returned `global_dim_dict`s.  Now there is one, so we should use it.
