### PR TITLE
Test on 3.4 on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
     - 2.7
     - 3.3
+    - 3.4
 before_install:
     - sudo apt-get update
     - sudo apt-get install libopenmpi-dev


### PR DESCRIPTION
Travis supports Python 3.4 now- and our tests pass!
