### PR TITLE
Test with 1 and 9 engines instead of 4 (on Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 env:
-    - NENGINES=4
+    - NENGINES=1
     - NENGINES=9
 python:
     - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+env:
+    - NENGINES=4
+    - NENGINES=9
 python:
     - 2.7
     - 3.3
@@ -25,7 +28,7 @@ install:
 before_script:
     - "export DISPLAY=:99.0"  # for plotting.py
     - "sh -e /etc/init.d/xvfb start"  # for plotting.py
-    - (cd $TRAVIS_BUILD_DIR && dacluster start)
+    - (cd $TRAVIS_BUILD_DIR && dacluster start -n$NENGINES)
     - lsof | grep python | wc -l
 script:
     - (cd $TRAVIS_BUILD_DIR && make test_with_coverage)


### PR DESCRIPTION
... on TravisCI, in parallel.

The 9-engine case should run all of the 4-engine tests (plus at least one more that requires 9), and the 1-engine case will test our resiliency to having fewer engines available than necessary.  It's the "worst" edge case in that direction.
