### PR TITLE
Only push coverage from one case in the test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,5 @@ after_script:
     - lsof | grep python | wc -l
     - (cd $TRAVIS_BUILD_DIR && dacluster stop)
 after_success:
-    - coverage combine
-    - coveralls
+    - if [[ $TRAVIS_PYTHON_VERSION == "3.4" && $NENGINES -eq 9 ]] ; then echo "coverage combine"; coverage combine; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == "3.4" && $NENGINES -eq 9 ]] ; then echo "coveralls"; coveralls; fi


### PR DESCRIPTION
... and echo the command on this selected test case (Python 3.4, 9 engines).

Previously, the coverage was sometimes computed from one of the 1-engine test scenarios, which skip many of our tests.
