### PR TITLE
One do a single 1-engine test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 env:
-    - PYVERSION="2.7" NENGINES=1
-    - PYVERSION="2.7" NENGINES=9
-    - PYVERSION="3.3" NENGINES=9
-    - PYVERSION="3.4" NENGINES=9
+    - PYVERSION="2.7"   NENGINES=1
+    - PYVERSION="2.7"   NENGINES=9
+    - PYVERSION="3.3"   NENGINES=9
+    - PYVERSION="3.4"   NENGINES=9
 before_install:
     - sudo add-apt-repository -y ppa:andrikos/ppa
     - sudo apt-get update


### PR DESCRIPTION
This is really just testing our test suite's ability to handle a small number of available engines.  We don't need to test all three python versions with 1 engine; one python version is sufficient.
