### PR TITLE
Make BaseContext into an Abstract Base Class

### DIFF
--- a/distarray/dist/context.py
+++ b/distarray/dist/context.py
@@ -62,18 +62,6 @@ class BaseContext(object):
         pass
 
     @abstractmethod
-    def _execute(self, lines, targets):
-        pass
-
-    @abstractmethod
-    def _push(self, d, targets):
-        pass
-
-    @abstractmethod
-    def _pull(self, k, targets):
-        pass
-
-    @abstractmethod
     def apply(self, func, args=None, kwargs=None, targets=None):
         pass
 


### PR DESCRIPTION
It's not meant to be instantiated on its own, and making it an ABC (with `abstractmethod`s) highlights what the subclasses implement.

If we wanted to make `BaseContext` more purely an interface, we could pull out an `ArrayCreationMixin` and an `IOMixin`.  Just an idea :)
