### PR TITLE
Adds Context() factory function.

### DIFF
--- a/distarray/testing.py
+++ b/distarray/testing.py
@@ -163,7 +163,7 @@ class ClientTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # skip if there isn't a cluster available
-        if Context is IPythonContext:
+        if IPythonContext is not None:
             try:
                 cls.client = IPythonClient()
             except EnvironmentError:
@@ -173,7 +173,7 @@ class ClientTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if Context is IPythonContext:
+        if IPythonContext is not None:
             try:
                 cls.client.close()
             except RuntimeError:


### PR DESCRIPTION
Takes 'kind' argument to allow user to select kind of context, either
'MPI' or 'IPython'.
