### PR TITLE
Simplify array creation.

### DIFF
--- a/distarray/dist/maps.py
+++ b/distarray/dist/maps.py
@@ -519,6 +519,13 @@ class UnstructuredMap(MapBase):
 # N-Dimensional map.
 # ---------------------------------------------------------------------------
 
+def asdistribution(context, shape_or_dist, dist=None, grid_shape=None, targets=None):
+    if isinstance(shape_or_dist, Distribution):
+        return shape_or_dist
+    return Distribution(context=context, shape=shape_or_dist,
+                        dist=dist, grid_shape=grid_shape,
+                        targets=targets)
+
 class Distribution(object):
 
     """ Governs the mapping between global indices and process ranks for

--- a/distarray/dist/random.py
+++ b/distarray/dist/random.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import
 
 from distarray.dist.distarray import DistArray
+from distarray.dist.maps import asdistribution
 
 
 class Random(object):
@@ -43,7 +44,7 @@ class Random(object):
                            (seed, self.context.comm),
                            targets=self.context.targets)
 
-    def rand(self, distribution):
+    def rand(self, shape_or_dist):
         """Random values over a given distribution.
 
         Create a distarray of the given shape and propagate it with
@@ -52,7 +53,7 @@ class Random(object):
 
         Parameters
         ----------
-        distribution : Distribution object
+        shape_or_dist : shape tuple or Distribution object
 
         Returns
         -------
@@ -60,9 +61,9 @@ class Random(object):
             Random values.
 
         """
-        return self._local_rand_call('rand', distribution)
+        return self._local_rand_call('rand', shape_or_dist)
 
-    def normal(self, distribution, loc=0.0, scale=1.0):
+    def normal(self, shape_or_dist, loc=0.0, scale=1.0):
         """Draw random samples from a normal (Gaussian) distribution.
 
         The probability density function of the normal distribution, first
@@ -81,7 +82,7 @@ class Random(object):
             Mean ("centre") of the distribution.
         scale : float
             Standard deviation (spread or "width") of the distribution.
-        distribution : Distribution object
+        shape_or_dist : shape tuple or Distribution object
 
         Notes
         -----
@@ -109,10 +110,10 @@ class Random(object):
                pp. 51, 51, 125.
 
         """
-        return self._local_rand_call('normal', distribution,
+        return self._local_rand_call('normal', shape_or_dist,
                                      dict(loc=loc, scale=scale))
 
-    def randint(self, distribution, low, high=None):
+    def randint(self, shape_or_dist, low, high=None):
         """Return random integers from `low` (inclusive) to `high` (exclusive).
 
         Return random integers from the "discrete uniform" distribution in the
@@ -121,7 +122,7 @@ class Random(object):
 
         Parameters
         ----------
-        distribution : Distribution object
+        shape_or_dist : shape tuple or Distribution object
         low : int
             Lowest (signed) integer to be drawn from the distribution (unless
             ``high=None``, in which case this parameter is the *highest* such
@@ -136,15 +137,15 @@ class Random(object):
             DistArray of random integers from the appropriate distribution.
 
         """
-        return self._local_rand_call('randint', distribution,
+        return self._local_rand_call('randint', shape_or_dist,
                                      dict(low=low, high=high))
 
-    def randn(self, distribution):
+    def randn(self, shape_or_dist):
         """Return samples from the "standard normal" distribution.
 
         Parameters
         ----------
-        distribution : Distribution object
+        shape_or_dist : shape tuple or Distribution object
 
         Returns
         -------
@@ -152,9 +153,9 @@ class Random(object):
             A DistArray of floating-point samples from the standard normal
             distribution.
         """
-        return self._local_rand_call('randn', distribution)
+        return self._local_rand_call('randn', shape_or_dist)
 
-    def _local_rand_call(self, local_func_name, distribution, kwargs=None):
+    def _local_rand_call(self, local_func_name, shape_or_dist, kwargs=None):
 
         kwargs = kwargs or {}
 
@@ -169,6 +170,7 @@ class Random(object):
             dist = Distribution(dim_data=dim_data, comm=comm)
             return proxyize(local_func(distribution=dist, **kwargs))
 
+        distribution = asdistribution(self.context, shape_or_dist)
         ddpr = distribution.get_dim_data_per_rank()
         args = (distribution.comm, local_func_name, ddpr, kwargs)
 

--- a/distarray/dist/tests/test_context.py
+++ b/distarray/dist/tests/test_context.py
@@ -157,16 +157,15 @@ class TestRegister(DefaultContextTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestRegister, cls).setUpClass()
-        distribution = Distribution(cls.context, (5, 5))
-        cls.da = cls.context.empty(distribution)
+        cls.da = cls.context.empty((5, 5))
         cls.da.fill(2 * numpy.pi)
 
     def test_local(self):
         context = Context()
 
-        distribution = Distribution(context, (4, 4))
-        da = context.empty(distribution)
-        a = numpy.empty((4, 4))
+        shape = (4, 4)
+        da = context.empty(shape)
+        a = numpy.empty(shape)
 
         def fill_a(a):
             for (i, j), _ in numpy.ndenumerate(a):
@@ -290,21 +289,18 @@ class TestPrimeCluster(DefaultContextTestCase):
     ntargets = 3
 
     def test_1D(self):
-        d = Distribution(self.context, (3,))
-        a = self.context.empty(d)
+        a = self.context.empty((3,))
         self.assertEqual(a.grid_shape, (3,))
 
     def test_2D(self):
-        da = Distribution(self.context, (3, 3))
-        a = self.context.empty(da)
+        a = self.context.empty((3, 3))
         db = Distribution(self.context, (3, 3), dist=('n', 'b'))
         b = self.context.empty(db)
         self.assertEqual(a.grid_shape, (3, 1))
         self.assertEqual(b.grid_shape, (1, 3))
 
     def test_3D(self):
-        da = Distribution(self.context, (3, 3, 3))
-        a = self.context.empty(da)
+        a = self.context.empty((3, 3, 3))
         db = Distribution(self.context, (3, 3, 3),
                                      dist=('n', 'b', 'n'))
         b = self.context.empty(db)

--- a/distarray/dist/tests/test_distarray.py
+++ b/distarray/dist/tests/test_distarray.py
@@ -891,7 +891,7 @@ class TestReduceMethods(DefaultContextTestCase):
         arr.fill(3)
         dist = Distribution(self.context, shape=shape,
                             dist=('c', 'c', 'c', 'c'))
-        darr = self.context.empty(distribution=dist)
+        darr = self.context.empty(shape_or_dist=dist)
         darr.fill(3)
         for axis in range(4):
             arr_sum = arr.sum(axis=axis)

--- a/distarray/dist/tests/test_random.py
+++ b/distarray/dist/tests/test_random.py
@@ -26,29 +26,32 @@ class TestRandom(DefaultContextTestCase):
         super(TestRandom, cls).setUpClass()
         cls.random = Random(cls.context)
 
-    def test_rand(self):
+    def test_shape_or_distribution(self):
         shape = (3, 4)
         distribution = Distribution(context=self.context, shape=shape)
-        a = self.random.rand(distribution)
+        a = self.random.randn(distribution)
+        b = self.random.randn(shape)
+        self.assertTrue(a.distribution.is_compatible(b.distribution))
+
+    def test_rand(self):
+        shape = (3, 4)
+        a = self.random.rand(shape)
         self.assertEqual(a.shape, shape)
 
     def test_normal(self):
-        shape = (3, 4)  # aka shape
-        distribution = Distribution(context=self.context, shape=shape)
-        a = self.random.normal(distribution)
+        shape = (3, 4)
+        a = self.random.normal(shape)
         self.assertEqual(a.shape, shape)
 
     def test_randint(self):
         low = 1
-        shape = (3, 4)  # aka shape
-        distribution = Distribution(context=self.context, shape=shape)
-        a = self.random.randint(distribution, low=low)
+        shape = (3, 4)
+        a = self.random.randint(shape, low=low)
         self.assertEqual(a.shape, shape)
 
     def test_randn(self):
         shape = (3, 4)
-        distribution = Distribution(context=self.context, shape=shape)
-        a = self.random.randn(distribution)
+        a = self.random.randn(shape)
         self.assertEqual(a.shape, shape)
 
     def test_seed_same(self):


### PR DESCRIPTION
ones, zeros, empty, random creation, etc. all accept either a shape
tuple or a Distribution object.  Matches NumPy API more closely.
