### PR TITLE
Fiddle with badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,11 @@
 .. image:: https://readthedocs.org/projects/distarray/badge/?version=master
    :target: http://distarray.readthedocs.org/en/master/
 
+.. pypi badge
+.. image:: https://badge.fury.io/py/distarray.svg
+    :target: http://badge.fury.io/py/distarray
+
+
 .. All content before the next comment will be stripped off for release.
 .. *** begin README content ***
 


### PR DESCRIPTION
Remove the coveralls badge since it was always laggy and the coverage results themselves aren't accurate for our project.  We should probably get rid of the rest of the coveralls stuff too, though this is the only public-facing aspect.

Also, add a docs badge (readthedocs) and a pypi badge.
