### PR TITLE
Fix a typo in our mailing list address.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -113,7 +113,7 @@ notebooks and python scripts in the ``examples`` directory.  To start, see the
 
 If you have questions or would like to contribute, contact us
 
-* on the DistArray mailing list:  distarray.googlegroups.com,
+* on the DistArray mailing list:  distarray@googlegroups.com,
 * in the DistArray IRC channel: #distarray on freenode, or
 * through the DistArray GitHub repo: https://github.com/enthought/distarray
   (for bug reports and pull requests).


### PR DESCRIPTION
I made a mistake in `index.rst` in `docs` when giving our mailing list address.  This fixes that.
