### PR TITLE
Fix travis errors related to sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ before_install:
     - sudo add-apt-repository -y ppa:andrikos/ppa
     - sudo apt-get update
     - if [[ "$PYVERSION" == "2.7" ]]; then
-          wget http://repo.continuum.io/miniconda/Miniconda-3.5.5-Linux-x86_64.sh -O miniconda.sh;
+          wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
       else
-          wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh -O miniconda.sh;
+          wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
       fi
     - bash miniconda.sh -b -p $HOME/miniconda
     - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
     - conda info -a
     - conda create -q -n test-environment python=$PYVERSION setuptools pip numpy=1.8.1 pyzmq ipython matplotlib cython sphinx mock coverage requests pyyaml
     - source activate test-environment
-    - pip install sphinxcontrib-napoleon sphinxcontrib-programoutput coveralls
+    - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican
     - if [[ "$PYVERSION" == "2.7" ]]; then
           conda install mpi4py;

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -46,12 +46,12 @@ sys.path.insert(0, os.path.abspath('../../distarray'))
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.3'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.mathjax',
-              'sphinx.ext.autosummary', 'sphinxcontrib.napoleon',
+              'sphinx.ext.autosummary', 'sphinx.ext.napoleon',
               'sphinxcontrib.programoutput']
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
With the latest Sphinx (1.3), the `napoleon` extension is included, so `pip install sphinxcontrib` is no longer needed, and it was causing errors. 