### PR TITLE
Update / simplify TravisCI dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - PYVERSION="3.3"   NENGINES=9
     - PYVERSION="3.4"   NENGINES=9
 before_install:
+    - sudo add-apt-repository -y ppa:andrikos/ppa
     - sudo apt-get update
     - if [[ "$PYVERSION" == "2.7" ]]; then
           wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -21,7 +22,7 @@ before_install:
     - source activate test-environment
     - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican
-    - sudo apt-get install libhdf5-mpich-dev
+    - sudo apt-get install libhdf5-mpich2-7 libhdf5-mpich2-dev  # from Nick Andrik's PPA
     - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.2.1 --install-option="--mpi"
 install:
     - python setup.py install  # build DistArray

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,7 @@ before_install:
     - conda info -a
     - conda create -q -n test-environment python=$PYVERSION setuptools pip numpy=1.8.2 pyzmq ipython matplotlib cython sphinx mock coverage requests pyyaml mpi4py
     - source activate test-environment
-    - pip install sphinxcontrib-programoutput coveralls
-    - pip install pelican
+    - pip install sphinxcontrib-programoutput coveralls pelican
     - sudo apt-get install libhdf5-mpich2-7 libhdf5-mpich2-dev  # from Nick Andrik's PPA
     - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.2.1 --install-option="--mpi"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
     - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican
     - sudo apt-get install libhdf5-mpich2-7 libhdf5-mpich2-dev  # from Nick Andrik's PPA
-    - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.5.0 --install-option="--mpi"
+    - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.2.1 --install-option="--mpi"
 install:
     - python setup.py install  # build DistArray
     - (cd $TRAVIS_BUILD_DIR/docs/sphinx && make html)  # build docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,19 +20,20 @@ before_install:
     - conda info -a
     - conda create -q -n test-environment python=$PYVERSION setuptools pip numpy=1.8.2 pyzmq ipython matplotlib cython sphinx mock coverage requests pyyaml mpi4py
     - source activate test-environment
-    - conda install -c https://conda.binstar.org/cbillington h5py-mpi
     - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican
+    - sudo apt-get install libhdf5-mpich2-7 libhdf5-mpich2-dev  # from Nick Andrik's PPA
+    - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.2.1 --install-option="--mpi"
 install:
     - python setup.py install  # build DistArray
     - (cd $TRAVIS_BUILD_DIR/docs/sphinx && make html)  # build docs
     - (cd $TRAVIS_BUILD_DIR/docs/www && make html)  # build docs
 before_script:
+    - python -c "import numpy; print('Numpy version', numpy.__version__)"
     - "export DISPLAY=:99.0"  # for plotting.py
     - "sh -e /etc/init.d/xvfb start"  # for plotting.py
     - (cd $TRAVIS_BUILD_DIR && dacluster start -n$NENGINES)
     - lsof | grep python | wc -l
-    - python -c "import numpy; print('Numpy version', numpy.__version__)"
 script:
     - (cd $TRAVIS_BUILD_DIR && make test_with_coverage)
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
     - PYVERSION="3.3"   NENGINES=9
     - PYVERSION="3.4"   NENGINES=9
 before_install:
-    - sudo add-apt-repository -y ppa:andrikos/ppa
     - sudo apt-get update
     - if [[ "$PYVERSION" == "2.7" ]]; then
           wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -22,7 +21,7 @@ before_install:
     - source activate test-environment
     - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican
-    - sudo apt-get install libhdf5-mpich2-7 libhdf5-mpich2-dev  # from Nick Andrik's PPA
+    - sudo apt-get install libhdf5-mpich-dev
     - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.2.1 --install-option="--mpi"
 install:
     - python setup.py install  # build DistArray

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,11 @@ before_install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda info -a
-    - conda create -q -n test-environment python=$PYVERSION setuptools pip numpy=1.8.2 pyzmq ipython matplotlib cython sphinx mock coverage requests pyyaml
+    - conda create -q -n test-environment python=$PYVERSION setuptools pip numpy=1.8.2 pyzmq ipython matplotlib cython sphinx mock coverage requests pyyaml mpi4py
     - source activate test-environment
     - python -c "import numpy; print('Numpy version', numpy.__version__)"
     - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican
-    - if [[ "$PYVERSION" == "2.7" ]]; then
-          conda install mpi4py;
-      else
-          sudo apt-get install libmpich2-dev mpich2;
-          pip install mpi4py --allow-all-external --allow-unverified mpi4py;
-      fi
     - sudo apt-get install libhdf5-mpich2-7 libhdf5-mpich2-dev  # from Nick Andrik's PPA
     - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.2.1 --install-option="--mpi"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
     - conda info -a
     - conda create -q -n test-environment python=$PYVERSION setuptools pip numpy=1.8.2 pyzmq ipython matplotlib cython sphinx mock coverage requests pyyaml
     - source activate test-environment
+    - python -c "import numpy; print('Numpy version', numpy.__version__)"
     - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican
     - if [[ "$PYVERSION" == "2.7" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,9 @@ before_install:
     - conda info -a
     - conda create -q -n test-environment python=$PYVERSION setuptools pip numpy=1.8.2 pyzmq ipython matplotlib cython sphinx mock coverage requests pyyaml mpi4py
     - source activate test-environment
-    - python -c "import numpy; print('Numpy version', numpy.__version__)"
+    - conda install -c https://conda.binstar.org/cbillington h5py-mpi
     - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican
-    - sudo apt-get install libhdf5-mpich2-7 libhdf5-mpich2-dev  # from Nick Andrik's PPA
-    - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.2.1 --install-option="--mpi"
 install:
     - python setup.py install  # build DistArray
     - (cd $TRAVIS_BUILD_DIR/docs/sphinx && make html)  # build docs
@@ -34,6 +32,7 @@ before_script:
     - "sh -e /etc/init.d/xvfb start"  # for plotting.py
     - (cd $TRAVIS_BUILD_DIR && dacluster start -n$NENGINES)
     - lsof | grep python | wc -l
+    - python -c "import numpy; print('Numpy version', numpy.__version__)"
 script:
     - (cd $TRAVIS_BUILD_DIR && make test_with_coverage)
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
     - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican
     - sudo apt-get install libhdf5-mpich2-7 libhdf5-mpich2-dev  # from Nick Andrik's PPA
-    - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.2.1 --install-option="--mpi"
+    - CC=mpicc pip install git+https://github.com/h5py/h5py.git@2.5.0 --install-option="--mpi"
 install:
     - python setup.py install  # build DistArray
     - (cd $TRAVIS_BUILD_DIR/docs/sphinx && make html)  # build docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda info -a
-    - conda create -q -n test-environment python=$PYVERSION setuptools pip numpy=1.8.1 pyzmq ipython matplotlib cython sphinx mock coverage requests pyyaml
+    - conda create -q -n test-environment python=$PYVERSION setuptools pip numpy=1.8.2 pyzmq ipython matplotlib cython sphinx mock coverage requests pyyaml
     - source activate test-environment
     - pip install sphinxcontrib-programoutput coveralls
     - pip install pelican


### PR DESCRIPTION
On TravisCI:
* Bump numpy version to 1.8.2
* simplify mpi4py installation