### PR TITLE
Sphinx now omits a warning with 'default'.

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -118,7 +118,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
'alabaster' is the new default.