### PR TITLE
Update links on www

### DIFF
--- a/docs/www/content/talks/2014-06-11-apug.rst
+++ b/docs/www/content/talks/2014-06-11-apug.rst
@@ -11,7 +11,9 @@ Robert Grant presented DistArray to the Austin Python User's group in June
 * `APUG Announcement`_
 * `Slides`_
 * `IPython Notebook`_
- 
+* `Recorded presentation`_
+
 .. _APUG Announcement: http://www.meetup.com/austinpython/events/183962712/
 .. _Slides: https://github.com/enthought/distarray/blob/master/docs/talks/2014-06-apug/2014-06-apug.pdf?raw=true
 .. _IPython Notebook: http://nbviewer.ipython.org/github/enthought/distarray/blob/master/docs/talks/2014-06-apug/2014-06-apug.ipynb
+.. _Recorded presentation: https://youtu.be/gqCJON4Jknw?t=4m14s

--- a/docs/www/content/talks/2015-07-08-scipy-talk.rst
+++ b/docs/www/content/talks/2015-07-08-scipy-talk.rst
@@ -1,4 +1,4 @@
-:date: 2015-07-09
+:date: 2015-07-08
 :category: Talks
 :tags: talks
 

--- a/docs/www/content/talks/2015-07-08-scipy-talk.rst
+++ b/docs/www/content/talks/2015-07-08-scipy-talk.rst
@@ -7,6 +7,8 @@ SciPy 2015 DistArray Talk
 
 Robert Grant gave a DistArray talk at SciPy 2015 in Austin, TX.
 
+* `Slides`_
 * `Recorded presentation`_
 
+.. _Slides: https://github.com/enthought/distarray/raw/master/docs/talks/2015-07-08-scipy/2015-07-08-scipy.pdf?raw=true
 .. _Recorded presentation: https://www.youtube.com/watch?v=Dac1pfEn2rE

--- a/docs/www/content/talks/2015-07-09-scipy-talk.rst
+++ b/docs/www/content/talks/2015-07-09-scipy-talk.rst
@@ -1,0 +1,12 @@
+:date: 2015-07-09
+:category: Talks
+:tags: talks
+
+SciPy 2015 DistArray Talk
+=========================
+
+Robert Grant gave a DistArray talk at SciPy 2015 in Austin, TX.
+
+* `Recorded presentation`_
+
+.. _Recorded presentation: https://www.youtube.com/watch?v=Dac1pfEn2rE


### PR DESCRIPTION
Add links to

* SciPy 2015 video and slides
* APUG 2014 video (someone posted it!)

These changes are already live (in the website).

Closes #617, #610 .