### PR TITLE
Use MPI._typedict instead of MPI.__TypeDict__

### DIFF
--- a/distarray/localapi/localarray.py
+++ b/distarray/localapi/localarray.py
@@ -56,7 +56,7 @@ def _mpi_dtype_from_intervals(larr, glb_intervals):
     local_intervals = _massage_indices(larr.distribution, glb_intervals)
     blocklengths = [stop-start for (start, stop) in local_intervals]
     displacements = [start for (start, _) in local_intervals]
-    mpidtype = MPI.__TypeDict__[np.sctype2char(larr.dtype)]
+    mpidtype = MPI._typedict[np.sctype2char(larr.dtype)]
     newtype = mpidtype.Create_indexed(blocklengths, displacements)
     newtype.Commit()
     return newtype

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ else:
     install_requires = [
         'ipyparallel',
         'numpy',
-        'mpi4py'
+        'mpi4py >= 2.0.0'
     ]
 
 


### PR DESCRIPTION
In mpi4py/mpi4py@8fe8cfd39db3b9432365af22cca4dbd5d057f8ee mpi4py 2.0.0, `MPI.__TypeDict__` was renamed to `MPI._typedict`. This change caters for the update.

I've also required mpi4py 2.0.0 in setup.py, but I'm not sure how strict you want to be with your version dependencies.
