### PR TITLE
Implement a broadcasting distribution

### DIFF
--- a/distarray/globalapi/maps.py
+++ b/distarray/globalapi/maps.py
@@ -184,7 +184,7 @@ class MapBase(object):
         pass
 
     def _is_compatible_degenerate(self, map):
-        right_types = all(isinstance(m, (NoDistMap, BlockMap, BlockCyclicMap))
+        right_types = all(isinstance(m, (NoDistMap, BlockMap, BroadcastMap, BlockCyclicMap))
                           for m in (self, map))
         return (right_types
                 and self.grid_size == map.grid_size == 1
@@ -273,7 +273,7 @@ class NoDistMap(MapBase):
         return self.__class__(size=int(new_dimsize), grid_size=1)
 
     def is_compatible(self, other):
-        return (isinstance(other, (NoDistMap, BlockMap, BlockCyclicMap)) and
+        return (isinstance(other, (NoDistMap, BlockMap, BroadcastMap, BlockCyclicMap)) and
                 other.grid_size == self.grid_size and 
                 other.size == self.size)
 

--- a/distarray/globalapi/maps.py
+++ b/distarray/globalapi/maps.py
@@ -74,6 +74,7 @@ def choose_map(dist_type):
     """Choose a map class given one of the distribution types."""
     cls_from_dist_type = {
         'b': BlockMap,
+        'm': MirrorMap,
         'c': BlockCyclicMap,
         'n': NoDistMap,
         'u': UnstructuredMap,
@@ -406,6 +407,137 @@ class BlockMap(MapBase):
         if isinstance(other, NoDistMap):
             return other.is_compatible(self)
         return super(BlockMap, self).is_compatible(other)
+
+
+class MirrorMap(MapBase):
+
+    dist = 'm'
+
+    @classmethod
+    def from_global_dim_dict(cls, glb_dim_dict):
+        if glb_dim_dict['dist_type'] != 'm':
+            msg = "Wrong dist_type (%r) for mirror map."
+            raise ValueError(msg % glb_dim_dict['dist_type'])
+
+        bounds = glb_dim_dict['bounds']
+        tuple_bounds = list(zip(bounds[:-1], bounds[1:]))
+
+        size = bounds[-1]
+        grid_size = max(len(bounds) - 1, 1)
+
+        comm_padding = int(glb_dim_dict.get('comm_padding', 0))
+        boundary_padding = int(glb_dim_dict.get('boundary_padding', 0))
+
+        return cls(size=size, grid_size=grid_size, bounds=tuple_bounds,
+                   comm_padding=comm_padding,
+                   boundary_padding=boundary_padding)
+
+    @classmethod
+    def from_axis_dim_dicts(cls, axis_dim_dicts):
+        dd = axis_dim_dicts[0]
+        if dd['dist_type'] != 'm':
+            msg = "Wrong dist_type (%r) for mirror map."
+            raise ValueError(msg % dd['dist_type'])
+
+        size = dd['size']
+        grid_size = dd['proc_grid_size']
+        if grid_size != len(axis_dim_dicts):
+            msg = ("Number of dimension dictionaries (%r)"
+                   "inconsistent with proc_grid_size (%r).")
+            raise ValueError(msg % (len(axis_dim_dicts), grid_size))
+        bounds = [(d['start'], d['stop']) for d in axis_dim_dicts]
+        boundary_padding, comm_padding = dd.get('padding', (0, 0))
+
+        return cls(size=size, grid_size=grid_size, bounds=bounds,
+                   comm_padding=comm_padding,
+                   boundary_padding=boundary_padding)
+
+    def __init__(self, size, grid_size, bounds=None,
+                 comm_padding=None, boundary_padding=None):
+        self.size = size
+        self.grid_size = grid_size
+        if bounds is None:
+            self.bounds = [_start_stop_block(size, grid_size, grid_rank)
+                           for grid_rank in range(grid_size)]
+        else:
+            self.bounds = bounds
+        self.comm_padding = comm_padding or 0
+        self.boundary_padding = boundary_padding or 0
+
+    def index_owners(self, idx):
+        coords = []
+        for (coord, (lower, upper)) in enumerate(self.bounds):
+            if lower <= idx < upper:
+                coords.append(coord)
+        return coords
+
+    def slice_owners(self, idx):
+        coords = []
+        start = idx.start if idx.start is not None else 0
+        stop = idx.stop if idx.stop is not None else self.size
+        step = idx.step if idx.step is not None else 1
+        for (coord, (lower, upper)) in enumerate(self.bounds):
+            if tuple_intersection((start, stop, step), (lower, upper)):
+                coords.append(coord)
+        return coords
+
+    def get_dimdicts(self):
+        bounds = self.bounds or [[0, 0]]
+        grid_ranks = range(len(bounds))
+        cpadding = self.comm_padding
+        padding = [[cpadding, cpadding] for _ in grid_ranks]
+        if len(padding) > 0:
+            padding[0][0] = self.boundary_padding
+            padding[-1][-1] = self.boundary_padding
+        data_tuples = zip(grid_ranks, padding, bounds)
+        # Build the result
+        out = []
+        for grid_rank, padding, (start, stop) in data_tuples:
+            out.append({
+                'dist_type': 'm',
+                'size': self.size,
+                'proc_grid_size': self.grid_size,
+                'proc_grid_rank': grid_rank,
+                'start': start,
+                'stop': stop,
+                'padding': padding,
+                })
+        return tuple(out)
+
+    def slice(self, idx):
+        """Make a new Map from a slice."""
+        new_bounds = [0]
+        start = idx.start if idx.start is not None else 0
+        step = idx.step if idx.step is not None else 1
+        # iterate over the processes in this dimension
+        for proc_start, proc_stop in self.bounds:
+            stop = idx.stop if idx.stop is not None else proc_stop
+            isection = tuple_intersection((start, stop, step),
+                                          (proc_start, proc_stop))
+            if isection:
+                isection_size = int(np.ceil((isection[1] - (isection[0])) / step))
+                new_bounds.append(isection_size + new_bounds[-1])
+        if new_bounds == [0]:
+            new_bounds = []
+
+        size = new_bounds[-1] if len(new_bounds) > 0 else 0
+        grid_size = max(len(new_bounds) - 1, 1)
+        new_bounds = list(zip(new_bounds[:-1], new_bounds[1:]))
+        return self.__class__(size=size, grid_size=grid_size,
+                              bounds=new_bounds)
+
+    def view(self, new_dimsize):
+        """Scale this map for the `view` method."""
+        factor = new_dimsize / self.size
+        new_bounds = [(int(start*factor), int(stop*factor))
+                      for (start, stop) in self.bounds]
+        return self.__class__(size=int(new_dimsize), grid_size=self.grid_size,
+                              bounds=new_bounds)
+
+    def is_compatible(self, other):
+        if isinstance(other, NoDistMap):
+            return other.is_compatible(self)
+        return super(MirrorMap, self).is_compatible(other)
 
 
 class BlockCyclicMap(MapBase):

--- a/distarray/globalapi/maps.py
+++ b/distarray/globalapi/maps.py
@@ -477,8 +477,6 @@ class MirrorMap(MapBase):
                 'size': self.size,
                 'proc_grid_size': self.grid_size,
                 'proc_grid_rank': grid_rank,
-                'start': 0,
-                'stop': self.size,
                 'padding': padding,
                 })
         return tuple(out)

--- a/distarray/globalapi/maps.py
+++ b/distarray/globalapi/maps.py
@@ -74,7 +74,7 @@ def choose_map(dist_type):
     """Choose a map class given one of the distribution types."""
     cls_from_dist_type = {
         'b': BlockMap,
-        'm': MirrorMap,
+        'o': BroadcastMap,
         'c': BlockCyclicMap,
         'n': NoDistMap,
         'u': UnstructuredMap,
@@ -409,13 +409,13 @@ class BlockMap(MapBase):
         return super(BlockMap, self).is_compatible(other)
 
 
-class MirrorMap(MapBase):
+class BroadcastMap(MapBase):
 
-    dist = 'm'
+    dist = 'o'
 
     @classmethod
     def from_global_dim_dict(cls, glb_dim_dict):
-        if glb_dim_dict['dist_type'] != MirrorMap.dist:
+        if glb_dim_dict['dist_type'] != BroadcastMap.dist:
             msg = "Wrong dist_type (%r) for mirror map."
             raise ValueError(msg % glb_dim_dict['dist_type'])
 
@@ -432,7 +432,7 @@ class MirrorMap(MapBase):
     @classmethod
     def from_axis_dim_dicts(cls, axis_dim_dicts):
         dd = axis_dim_dicts[0]
-        if dd['dist_type'] != MirrorMap.dist:
+        if dd['dist_type'] != BroadcastMap.dist:
             msg = "Wrong dist_type (%r) for mirror map."
             raise ValueError(msg % dd['dist_type'])
 
@@ -473,7 +473,7 @@ class MirrorMap(MapBase):
         out = []
         for grid_rank, padding in data_tuples:
             out.append({
-                'dist_type': 'm',
+                'dist_type': 'o',
                 'size': self.size,
                 'proc_grid_size': self.grid_size,
                 'proc_grid_rank': grid_rank,
@@ -504,7 +504,7 @@ class MirrorMap(MapBase):
     def is_compatible(self, other):
         if isinstance(other, NoDistMap):
             return other.is_compatible(self)
-        return super(MirrorMap, self).is_compatible(other)
+        return super(BroadcastMap, self).is_compatible(other)
 
 
 class BlockCyclicMap(MapBase):

--- a/distarray/localapi/maps.py
+++ b/distarray/localapi/maps.py
@@ -197,8 +197,8 @@ def map_from_dim_dict(dd):
     if dist_type == 'b':
         return BlockMap(global_size=size, grid_size=grid_size,
                         grid_rank=grid_rank, start=start, stop=stop)
-    if dist_type == 'm':
-        return MirrorMap(global_size=size, grid_size=grid_size,
+    if dist_type == 'o':
+        return BroadcastMap(global_size=size, grid_size=grid_size,
                         grid_rank=grid_rank, size=size)
     if dist_type == 'c' and block_size == 1:
         return CyclicMap(global_size=size, grid_size=grid_size,
@@ -298,12 +298,12 @@ class BlockMap(MapBase):
         return slice(self.start, self.stop)
 
 
-class MirrorMap(MapBase):
+class BroadcastMap(MapBase):
     """
     One-dimensional mirror map class.
     """
 
-    dist = 'm'
+    dist = 'o'
 
     def __init__(self, global_size, grid_size, grid_rank, size):
         self.local_size = size

--- a/distarray/metadata_utils.py
+++ b/distarray/metadata_utils.py
@@ -51,8 +51,8 @@ def check_grid_shape_preconditions(shape, dist, comm_size):
     if any(i < 0 for i in shape):
         raise ValueError("shape must be a sequence of non-negative integers, "
                          "shape = %s" % (shape,))
-    if any(i not in ('b', 'c', 'n', 'u') for i in dist):
-        raise ValueError("dist must be a sequence of 'b', 'n', 'c', 'u' "
+    if any(i not in ('b', 'm', 'c', 'n', 'u') for i in dist):
+        raise ValueError("dist must be a sequence of 'b', 'm', 'n', 'c', 'u' "
                          "strings, dist = %s" % (dist,))
 
 
@@ -265,6 +265,7 @@ def distribute_indices(dd):
     try:
         {'n': lambda dd: None,
          'b': distribute_block_indices,
+         'm': lambda dd: None, # size is default
          'c': distribute_cyclic_indices}[dist_type](dd)
     except KeyError:
         msg = "dist_type %r not supported."
@@ -511,6 +512,7 @@ def size_chooser(dist_type):
     """
     chooser = {'n': non_dist_size,
                'b': block_size,
+               'm': non_dist_size,
                'c': c_or_bc_chooser,
                'u': unstructured_size}
     return chooser[dist_type]

--- a/distarray/metadata_utils.py
+++ b/distarray/metadata_utils.py
@@ -51,8 +51,8 @@ def check_grid_shape_preconditions(shape, dist, comm_size):
     if any(i < 0 for i in shape):
         raise ValueError("shape must be a sequence of non-negative integers, "
                          "shape = %s" % (shape,))
-    if any(i not in ('b', 'm', 'c', 'n', 'u') for i in dist):
-        raise ValueError("dist must be a sequence of 'b', 'm', 'n', 'c', 'u' "
+    if any(i not in ('b', 'o', 'c', 'n', 'u') for i in dist):
+        raise ValueError("dist must be a sequence of 'b', 'o', 'n', 'c', 'u' "
                          "strings, dist = %s" % (dist,))
 
 
@@ -265,7 +265,7 @@ def distribute_indices(dd):
     try:
         {'n': lambda dd: None,
          'b': distribute_block_indices,
-         'm': lambda dd: None, # size is default
+         'o': lambda dd: None, # size is default
          'c': distribute_cyclic_indices}[dist_type](dd)
     except KeyError:
         msg = "dist_type %r not supported."
@@ -512,7 +512,7 @@ def size_chooser(dist_type):
     """
     chooser = {'n': non_dist_size,
                'b': block_size,
-               'm': non_dist_size,
+               'o': non_dist_size,
                'c': c_or_bc_chooser,
                'u': unstructured_size}
     return chooser[dist_type]


### PR DESCRIPTION
I've added a BroadcastMap distribution type to distarray. This contains the basic implementation so far and I've opened the pull request to invite comment and test the waters.

distarray's basic philosophy is to distribute different sections of an array dimension over distinct processors. As far as I can tell, there is a one-to-one mapping here (with the possible exception of Unstructured Distributions).

A broadcast distribution changes this by broadcasting one array dimension over multiple processes.

I see a number of challenges here:
- Breaks the one-to-one mapping paradigm.
- Ensuring that local updates on one process propagate to other processes.
- Updates the `Distributed Array Protocol`

I've set up the dim data per rank dictionary to look something like this:

``` python
ddpr = {
    'dist_type': 'o',
    'size': N,                       # Array of size N
    'proc_grid_size': 4,      # 4 processors
    'proc_grid_rank': 1,     # This rank
}
```

Any comments? Would this be useful?
